### PR TITLE
Update README.md: Use --rm with docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Replace variables below to use docker version of this tool
 * `{YOUR_BACKUP_FOLDER_ON_THE_HOST}`: The backup folder on the host machine.
 
 ```
-docker run -it --name grafana-backup-tool \
+docker run --rm -it --name grafana-backup-tool \
    -e GRAFANA_TOKEN={YOUR_GRAFANA_TOKEN} \
    -e GRAFANA_URL={YOUR_GRAFANA_URL} \
    -v {YOUR_BACKUP_FOLDER_ON_THE_HOST}:/opt/grafana-backup-tool/_OUTPUT_  \


### PR DESCRIPTION
Without --rm, subsequent runs will fail with an error such as:

    docker: Error response from daemon: Conflict. The container name "/grafana-backup-tool" is already in use by container "e8a6c8a7b717dd52402ea75c7189002bbb80836ae641df1e9865e0f1ec7835b7". You have to remove (or rename) that container to be able to reuse that name.                                                             
    See 'docker run --help'.