### PR TITLE
exit on error and note

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A Python-based application to backup Grafana settings via [Grafana API](http://d
 `gafana-backup-tool` uses environment variables to define the connection to a Grafana server, or alternatively hard-coded settings in `src/grafanaSettings.py`.
 You need to add the following to your `.bashrc` or execute once before using the tool:
 ```bash
-export GRAFANA_URL=http://some.host.org:3000/
+# do not use a trailing slash!
+export GRAFANA_URL=http://some.host.org:3000
 export GRAFANA_TOKEN=eyJrIjoidUhaU2ZQQndrWFN3RRVkUnVfrT56a1JoaG9KWFFObEgiLCJuIjoiYWRtaW4iLCJpZCI6MX0=
 ```
 

--- a/backup_grafana.sh
+++ b/backup_grafana.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 trap 'echo -ne "\n:::\n:::\tCaught signal, exiting at line $LINENO, while running :${BASH_COMMAND}:\n:::\n"; exit' SIGINT SIGQUIT
 
 current_path=$(pwd)

--- a/restore_grafana.sh
+++ b/restore_grafana.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 trap 'echo -ne "\n:::\n:::\tCaught signal, exiting at line $LINENO, while running :${BASH_COMMAND}:\n:::\n"; exit' SIGINT SIGQUIT
 
 current_path=$(pwd)


### PR DESCRIPTION
I just tried to get the tool working and ran into some issues. Debugging was hard because the script kept going past an initial error. Once looking at a single error and printing the URL the tool was using, I noticed an extra slash.

- backup  and restore: exit on error
- README: note that GRAFANA_URL should not have a trailing slash