### PR TITLE
search_api_limit can't be larger than 5000

### DIFF
--- a/src/grafanaSettings.py
+++ b/src/grafanaSettings.py
@@ -4,6 +4,6 @@ GRAFANA_URL = os.getenv('GRAFANA_URL', 'http://localhost:3000')
 TOKEN = os.getenv('GRAFANA_TOKEN', 'eyJrIjoiSkQ5NkdvWllHdnVNdlVhWUV3Tm5LSGc4NG53UFdSTjQiLCJuIjoiYWRtaW4iLCJpZCI6MX0=')
 HTTP_GET_HEADERS = {'Authorization': 'Bearer ' + TOKEN}
 HTTP_POST_HEADERS = {'Authorization': 'Bearer ' + TOKEN, 'Content-Type': 'application/json'}
-SEARCH_API_LIMIT = 10000
+SEARCH_API_LIMIT = 5000
 DEBUG = True
 VERIFY_SSL = False


### PR DESCRIPTION
The search_api_limit must not be larger than 5000 since April this year (grafana/grafana#16458). I figured this out today after upgrading grafana to 6.4.4 from 5.something.

Probably we should fix the search_dashboard() at some point to use pagination (for sites with more than 5000 dashboards, folders, datasource).