### PR TITLE
fix(casting): cast int to str

### DIFF
--- a/src/save_alert_channels.py
+++ b/src/save_alert_channels.py
@@ -37,12 +37,12 @@ def get_indivisual_alert_channel_and_save(channels):
             
         save_alert_channel(
             to_python2_and_3_compatible_string(channel['name']),
-            to_python2_and_3_compatible_string(channel_identifier),
+            to_python2_and_3_compatible_string(str(channel_identifier)),
             channel
         )
         file_path = folder_path + '/' + log_file
         with open(u"{0}".format(file_path) , 'w+') as f:
-            f.write('{}\t{}'.format(to_python2_and_3_compatible_string(channel_identifier), to_python2_and_3_compatible_string(channel['name'])))
+            f.write('{}\t{}'.format(to_python2_and_3_compatible_string(str(channel_identifier)), to_python2_and_3_compatible_string(channel['name'])))
 
 
 alert_channels = get_all_alert_channels_in_grafana()


### PR DESCRIPTION
To avoid this exception:
```
Traceback (most recent call last):
  File "/Users/xxxx/Downloads/Old_XPS/Documents/PROJETS/yyy/grafana-backup-tool/src/save_alert_channels.py", line 49, in <module>
    get_indivisual_alert_channel_and_save(alert_channels)
  File "/Users/xxxx/Downloads/Old_XPS/Documents/PROJETS/yyy/grafana-backup-tool/src/save_alert_channels.py", line 45, in get_indivisual_alert_channel_and_save
    f.write('{}\t{}'.format(to_python2_and_3_compatible_string(channel_identifier), to_python2_and_3_compatible_string(channel['name'])))
  File "/Users/xxxx/Downloads/Old_XPS/Documents/PROJETS/yyy/grafana-backup-tool/src/commons.py", line 23, in to_python2_and_3_compatible_string
    return some_string.encode('utf8')
AttributeError: 'int' object has no attribute 'encode'
```