### PR TITLE
Make GRAFANA_HEADERS environment optional

### DIFF
--- a/src/grafanaSettings.py
+++ b/src/grafanaSettings.py
@@ -3,10 +3,7 @@ import os
 GRAFANA_URL = os.getenv('GRAFANA_URL', 'http://localhost:3000')
 TOKEN = os.getenv('GRAFANA_TOKEN', 'eyJrIjoiSkQ5NkdvWllHdnVNdlVhWUV3Tm5LSGc4NG53UFdSTjQiLCJuIjoiYWRtaW4iLCJpZCI6MX0=')
 
-if 'GRAFANA_HEADERS' in os.environ:
-    EXTRA_HEADERS = dict(h.split(':') for h in os.getenv('GRAFANA_HEADERS').split(','))
-else:
-    EXTRA_HEADERS = {}
+EXTRA_HEADERS = dict(h.split(':') for h in os.getenv('GRAFANA_HEADERS', '').split(',') if 'GRAFANA_HEADERS' in os.environ)
 
 HTTP_GET_HEADERS = {'Authorization': 'Bearer ' + TOKEN, **EXTRA_HEADERS}
 HTTP_POST_HEADERS = {'Authorization': 'Bearer ' + TOKEN, 'Content-Type': 'application/json', **EXTRA_HEADERS}

--- a/src/grafanaSettings.py
+++ b/src/grafanaSettings.py
@@ -2,7 +2,12 @@ import os
 
 GRAFANA_URL = os.getenv('GRAFANA_URL', 'http://localhost:3000')
 TOKEN = os.getenv('GRAFANA_TOKEN', 'eyJrIjoiSkQ5NkdvWllHdnVNdlVhWUV3Tm5LSGc4NG53UFdSTjQiLCJuIjoiYWRtaW4iLCJpZCI6MX0=')
-EXTRA_HEADERS = dict(h.split(':') for h in os.getenv('GRAFANA_HEADERS').split(',') if 'GRAFANA_HEADERS' in os.environ)
+
+if 'GRAFANA_HEADERS' in os.environ:
+    EXTRA_HEADERS = dict(h.split(':') for h in os.getenv('GRAFANA_HEADERS').split(','))
+else:
+    EXTRA_HEADERS = {}
+
 HTTP_GET_HEADERS = {'Authorization': 'Bearer ' + TOKEN, **EXTRA_HEADERS}
 HTTP_POST_HEADERS = {'Authorization': 'Bearer ' + TOKEN, 'Content-Type': 'application/json', **EXTRA_HEADERS}
 SEARCH_API_LIMIT = 5000


### PR DESCRIPTION
The current solution does not allow the GRAFANA_HEADERS to be optional. Pulling the if statement outside the dictionary comprehension to allow the variable to be optional.