### PR TITLE
Introduces the settings option client_cert

### DIFF
--- a/grafana_backup/create_alert_channel.py
+++ b/grafana_backup/create_alert_channel.py
@@ -6,11 +6,12 @@ def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     with open(file_path, 'r') as f:
         data = f.read()
 
     alert_channel = json.loads(data)
-    result = create_alert_channel(json.dumps(alert_channel), grafana_url, http_post_headers, verify_ssl, debug)
+    result = create_alert_channel(json.dumps(alert_channel), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
     print("create alert_channel: {0}, status: {1}, msg: {2}".format(alert_channel['name'], result[0], result[1]))

--- a/grafana_backup/create_dashboard.py
+++ b/grafana_backup/create_dashboard.py
@@ -6,6 +6,7 @@ def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     with open(file_path, 'r') as f:
@@ -16,9 +17,9 @@ def main(args, settings, file_path):
 
     payload = {
         'dashboard': content['dashboard'],
-        'folderId': get_folder_id_from_old_folder_url(content['meta']['folderUrl'], grafana_url, http_post_headers, verify_ssl, debug),
+        'folderId': get_folder_id_from_old_folder_url(content['meta']['folderUrl'], grafana_url, http_post_headers, verify_ssl, client_cert, debug),
         'overwrite': True
     }
 
-    result = create_dashboard(json.dumps(payload), grafana_url, http_post_headers, verify_ssl, debug)
+    result = create_dashboard(json.dumps(payload), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
     print("create response status: {0}, msg: {1}".format(result[0], result[1]))

--- a/grafana_backup/create_datasource.py
+++ b/grafana_backup/create_datasource.py
@@ -6,11 +6,12 @@ def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     with open(file_path, 'r') as f:
         data = f.read()
 
     datasource = json.loads(data)
-    result = create_datasource(json.dumps(datasource), grafana_url, http_post_headers, verify_ssl, debug)
+    result = create_datasource(json.dumps(datasource), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
     print("create datasource: {0}, status: {1}, msg: {2}".format(datasource['name'], result[0], result[1]))

--- a/grafana_backup/create_folder.py
+++ b/grafana_backup/create_folder.py
@@ -6,11 +6,12 @@ def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     with open(file_path, 'r') as f:
         data = f.read()
 
     folder = json.loads(data)
-    result = create_folder(json.dumps(folder), grafana_url, http_post_headers, verify_ssl, debug)
+    result = create_folder(json.dumps(folder), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
     print("create result status: {0}, msg: {1}".format(result[0], result[1]))

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -2,33 +2,33 @@ import requests, json, re
 from grafana_backup.commons import log_response
 
 
-def health_check(grafana_url, http_get_headers, verify_ssl, debug):
+def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/health'.format(grafana_url)
     print("grafana health: {0}".format(url))
-    return send_grafana_get(url, http_get_headers, verify_ssl, debug)
+    return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 
 
-def search_dashboard(page, limit, grafana_url, http_get_headers, verify_ssl, debug):
+def search_dashboard(page, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/search/?type=dash-db&limit={1}&page={2}'.format(grafana_url, limit, page)
     print("search dashboard in grafana: {0}".format(url))
-    return send_grafana_get(url, http_get_headers, verify_ssl, debug)
+    return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 
 
-def get_dashboard(board_uri, grafana_url, http_get_headers, verify_ssl, debug):
+def get_dashboard(board_uri, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/dashboards/{1}'.format(grafana_url, board_uri)
     print("query dashboard uri: {0}".format(url))
-    (status_code, content) = send_grafana_get(url, http_get_headers, verify_ssl, debug)
+    (status_code, content) = send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
     return (status_code, content)
 
 
-def search_alert_channels(grafana_url, http_get_headers, verify_ssl, debug):
+def search_alert_channels(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/alert-notifications'.format(grafana_url)
     print("search alert channels in grafana: {0}".format(url))
-    return send_grafana_get(url, http_get_headers, verify_ssl, debug)
+    return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 
 
-def create_alert_channel(payload, grafana_url, http_post_headers, verify_ssl, debug):
-    return send_grafana_post('{0}/api/alert-notifications'.format(grafana_url), payload, http_post_headers, verify_ssl, debug)
+def create_alert_channel(payload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
+    return send_grafana_post('{0}/api/alert-notifications'.format(grafana_url), payload, http_post_headers, verify_ssl, client_cert, debug)
 
 
 def delete_dashboard(board_uri, grafana_url, http_post_headers):
@@ -37,37 +37,37 @@ def delete_dashboard(board_uri, grafana_url, http_post_headers):
     return int(status_code)
 
 
-def create_dashboard(payload, grafana_url, http_post_headers, verify_ssl, debug):
-    return send_grafana_post('{0}/api/dashboards/db'.format(grafana_url), payload, http_post_headers, verify_ssl, debug)
+def create_dashboard(payload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
+    return send_grafana_post('{0}/api/dashboards/db'.format(grafana_url), payload, http_post_headers, verify_ssl, client_cert, debug)
 
 
-def search_datasource(grafana_url, http_get_headers, verify_ssl, debug):
+def search_datasource(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     print("search datasources in grafana:")
-    return send_grafana_get('{0}/api/datasources'.format(grafana_url), http_get_headers, verify_ssl, debug)
+    return send_grafana_get('{0}/api/datasources'.format(grafana_url), http_get_headers, verify_ssl, client_cert, debug)
 
 
-def create_datasource(payload, grafana_url, http_post_headers, verify_ssl, debug):
-    return send_grafana_post('{0}/api/datasources'.format(grafana_url), payload, http_post_headers, verify_ssl, debug)
+def create_datasource(payload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
+    return send_grafana_post('{0}/api/datasources'.format(grafana_url), payload, http_post_headers, verify_ssl, client_cert, debug)
 
 
-def search_folders(grafana_url, http_get_headers, verify_ssl, debug):
+def search_folders(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     print("search folder in grafana:")
-    return send_grafana_get('{0}/api/search/?type=dash-folder'.format(grafana_url), http_get_headers, verify_ssl, debug)
+    return send_grafana_get('{0}/api/search/?type=dash-folder'.format(grafana_url), http_get_headers, verify_ssl, client_cert, debug)
 
 
-def get_folder(uid, grafana_url, http_get_headers, verify_ssl, debug):
-    (status_code, content) = send_grafana_get('{0}/api/folders/{1}'.format(grafana_url, uid), http_get_headers, verify_ssl, debug)
+def get_folder(uid, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
+    (status_code, content) = send_grafana_get('{0}/api/folders/{1}'.format(grafana_url, uid), http_get_headers, verify_ssl, client_cert, debug)
     print("query folder:{0}, status:{1}".format(uid, status_code))
     return (status_code, content)
 
 
-def get_folder_id_from_old_folder_url(folder_url, grafana_url, http_post_headers, verify_ssl, debug):
+def get_folder_id_from_old_folder_url(folder_url, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
     if folder_url != "":
         # Get folder uid
         matches = re.search('dashboards\/[A-Za-z0-9]{1}\/(.*)\/.*', folder_url)
         uid = matches.group(1)
 
-        response = get_folder(uid, grafana_url, http_post_headers, verify_ssl, debug)
+        response = get_folder(uid, grafana_url, http_post_headers, verify_ssl, client_cert, debug)
         if isinstance(response[1],dict):
             folder_data = response[1]
         else:
@@ -76,19 +76,19 @@ def get_folder_id_from_old_folder_url(folder_url, grafana_url, http_post_headers
     return 0
 
 
-def create_folder(payload, grafana_url, http_post_headers, verify_ssl, debug):
-    return send_grafana_post('{0}/api/folders'.format(grafana_url), payload, http_post_headers, verify_ssl, debug)
+def create_folder(payload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
+    return send_grafana_post('{0}/api/folders'.format(grafana_url), payload, http_post_headers, verify_ssl, client_cert, debug)
 
 
-def send_grafana_get(url, http_get_headers, verify_ssl, debug):
-    r = requests.get(url, headers=http_get_headers, verify=verify_ssl)
+def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
+    r = requests.get(url, headers=http_get_headers, verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
     return (r.status_code, r.json())
 
 
-def send_grafana_post(url, json_payload, http_post_headers, verify_ssl, debug):
-    r = requests.post(url, headers=http_post_headers, data=json_payload, verify=verify_ssl)
+def send_grafana_post(url, json_payload, http_post_headers, verify_ssl, client_cert, debug):
+    r = requests.post(url, headers=http_post_headers, data=json_payload, verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
     return (r.status_code, r.json())

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -18,6 +18,7 @@ def main(config_path):
 
     debug = config.get('general', {}).get('debug', True)
     verify_ssl = config.get('general', {}).get('verify_ssl', False)
+    client_cert = config.get('general', {}).get('client_cert', None)
     backup_dir = config.get('general', {}).get('backup_dir', '_OUTPUT_')
     aws_s3_bucket_name = config.get('aws', {}).get('s3_bucket_name', '')
     aws_s3_bucket_key = config.get('aws', {}).get('s3_bucket_key', '')
@@ -43,6 +44,8 @@ def main(config_path):
     if isinstance(VERIFY_SSL, str):
         VERIFY_SSL = json.loads(VERIFY_SSL.lower()) # convert environment variable string to bool
 
+    CLIENT_CERT = os.getenv('CLIENT_CERT', client_cert)
+
     BACKUP_DIR = os.getenv('BACKUP_DIR', backup_dir)
 
     EXTRA_HEADERS = dict(h.split(':') for h in os.getenv('GRAFANA_HEADERS', '').split(',') if 'GRAFANA_HEADERS' in os.environ)
@@ -61,6 +64,7 @@ def main(config_path):
     config_dict['SEARCH_API_LIMIT'] = SEARCH_API_LIMIT
     config_dict['DEBUG'] = DEBUG
     config_dict['VERIFY_SSL'] = VERIFY_SSL
+    config_dict['CLIENT_CERT'] = CLIENT_CERT
     config_dict['BACKUP_DIR'] = BACKUP_DIR
     config_dict['EXTRA_HEADERS'] = EXTRA_HEADERS
     config_dict['HTTP_GET_HEADERS'] = HTTP_GET_HEADERS

--- a/grafana_backup/save_alert_channels.py
+++ b/grafana_backup/save_alert_channels.py
@@ -10,6 +10,7 @@ def main(args, settings):
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     folder_path = '{0}/alert_channels/{1}'.format(backup_dir, timestamp)
@@ -18,13 +19,13 @@ def main(args, settings):
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
 
-    alert_channels = get_all_alert_channels_in_grafana(grafana_url, http_get_headers, verify_ssl, debug)
+    alert_channels = get_all_alert_channels_in_grafana(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     get_individual_alert_channel_and_save(alert_channels, folder_path, log_file)
     print_horizontal_line()
 
 
-def get_all_alert_channels_in_grafana(grafana_url, http_get_headers, verify_ssl, debug):
-    (status, content) = search_alert_channels(grafana_url, http_get_headers, verify_ssl, debug)
+def get_all_alert_channels_in_grafana(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
+    (status, content) = search_alert_channels(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     if status == 200:
         channels = content
         print("There are {0} channels:".format(len(channels)))

--- a/grafana_backup/save_dashboards.py
+++ b/grafana_backup/save_dashboards.py
@@ -11,6 +11,7 @@ def main(args, settings):
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     folder_path = '{0}/dashboards/{1}'.format(backup_dir, timestamp)
@@ -19,24 +20,24 @@ def main(args, settings):
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
 
-    (status, resp) = health_check(grafana_url, http_get_headers, verify_ssl, debug)
+    (status, resp) = health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     status = 200
     if status == 200:
         is_api_support_page_param = left_ver_newer_than_right_ver(resp['version'], "6.2.0")
         if is_api_support_page_param:
-            save_dashboards_above_Ver6_2(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug)
+            save_dashboards_above_Ver6_2(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         else:
-            save_dashboards(folder_path, log_file, limit, grafana_url, http_get_headers, verify_ssl, debug)
+            save_dashboards(folder_path, log_file, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     else:
         print("server status is not ok: {0}".format(resp))
 
 
-def get_all_dashboards_in_grafana(page, limit, grafana_url, http_get_headers, verify_ssl, debug):
+def get_all_dashboards_in_grafana(page, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     (status, content) = search_dashboard(page,
                                          limit,
                                          grafana_url,
                                          http_get_headers,
-                                         verify_ssl,
+                                         verify_ssl, client_cert,
                                          debug)
     if status == 200:
         dashboards = content
@@ -57,12 +58,12 @@ def save_dashboard_setting(dashboard_name, file_name, dashboard_settings, folder
     print("dashboard: {0} -> saved to: {1}".format(dashboard_name, file_path))
 
 
-def get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug):
+def get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     file_path = folder_path + '/' + log_file
     if dashboards:
         with open(u"{0}".format(file_path), 'w') as f:
             for board in dashboards:
-                (status, content) = get_dashboard(board['uri'], grafana_url, http_get_headers, verify_ssl, debug)
+                (status, content) = get_dashboard(board['uri'], grafana_url, http_get_headers, verify_ssl, client_cert, debug)
                 if status == 200:
                     save_dashboard_setting(
                         to_python2_and_3_compatible_string(board['title']), 
@@ -73,23 +74,23 @@ def get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file,
                     f.write('{0}\t{1}\n'.format(board['uid'], to_python2_and_3_compatible_string(board['title'])))
 
 
-def save_dashboards_above_Ver6_2(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug):
+def save_dashboards_above_Ver6_2(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     limit = 5000 # limit is 5000 above V6.2+
     current_page = 1
     while True:
-        dashboards = get_all_dashboards_in_grafana(current_page, limit, grafana_url, http_get_headers, verify_ssl, debug)
+        dashboards = get_all_dashboards_in_grafana(current_page, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         print_horizontal_line()
         if len(dashboards) == 0:
             break
         else:
             current_page += 1
-        get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug)
+        get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         print_horizontal_line()
 
 
-def save_dashboards(folder_path, log_file, limit, grafana_url, http_get_headers, verify_ssl, debug):
+def save_dashboards(folder_path, log_file, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     current_page = 1
-    dashboards = get_all_dashboards_in_grafana(current_page, limit, grafana_url, http_get_headers, verify_ssl, debug)
+    dashboards = get_all_dashboards_in_grafana(current_page, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     print_horizontal_line()
-    get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug)
+    get_individual_dashboard_setting_and_save(dashboards, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     print_horizontal_line()

--- a/grafana_backup/save_datasources.py
+++ b/grafana_backup/save_datasources.py
@@ -10,6 +10,7 @@ def main(args, settings):
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     folder_path = '{0}/datasources/{1}'.format(backup_dir, timestamp)
@@ -18,7 +19,7 @@ def main(args, settings):
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
 
-    datasources = get_all_datasources_and_save(folder_path, grafana_url, http_get_headers, verify_ssl, debug)
+    datasources = get_all_datasources_and_save(folder_path, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     print_horizontal_line()
 
 
@@ -29,8 +30,8 @@ def save_datasource(file_name, datasource_setting, folder_path):
         print("datasource:{0} is saved to {1}".format(file_name, file_path))
 
 
-def get_all_datasources_and_save(folder_path, grafana_url, http_get_headers, verify_ssl, debug):
-    status_code_and_content = search_datasource(grafana_url, http_get_headers, verify_ssl, debug)
+def get_all_datasources_and_save(folder_path, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
+    status_code_and_content = search_datasource(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     if status_code_and_content[0] == 200:
         datasources = status_code_and_content[1]
         print("There are {0} datasources:".format(len(datasources)))

--- a/grafana_backup/save_folders.py
+++ b/grafana_backup/save_folders.py
@@ -10,6 +10,7 @@ def main(args, settings):
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
+    client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     folder_path = '{0}/folders/{1}'.format(backup_dir, timestamp)
@@ -18,14 +19,14 @@ def main(args, settings):
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
 
-    folders = get_all_folders_in_grafana(grafana_url, http_get_headers, verify_ssl, debug)
+    folders = get_all_folders_in_grafana(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     print_horizontal_line()
-    get_individual_folder_setting_and_save(folders, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug)
+    get_individual_folder_setting_and_save(folders, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     print_horizontal_line()
 
 
-def get_all_folders_in_grafana(grafana_url, http_get_headers, verify_ssl, debug):
-    status_and_content_of_all_folders = search_folders(grafana_url, http_get_headers, verify_ssl, debug)
+def get_all_folders_in_grafana(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
+    status_and_content_of_all_folders = search_folders(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     status = status_and_content_of_all_folders[0]
     content = status_and_content_of_all_folders[1]
     if status == 200:
@@ -46,9 +47,9 @@ def save_folder_setting(folder_name, file_name, folder_settings, folder_path):
     print("folder:{0} are saved to {1}".format(folder_name, file_path))
 
 
-def get_individual_folder_setting_and_save(folders, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, debug):
+def get_individual_folder_setting_and_save(folders, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     for folder in folders:
-        status_code_and_content = get_folder(folder['uid'], grafana_url, http_get_headers, verify_ssl, debug)
+        status_code_and_content = get_folder(folder['uid'], grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         if status_code_and_content[0] == 200:
             save_folder_setting(
                 to_python2_and_3_compatible_string(folder['title']), 


### PR DESCRIPTION
This commit introduces the settings option client_cert. It is now
possible to add a file path to a client certificate in the configuration
file or as an environment variable. The default is None.

* **config file:**

```
{
  "general": {
    ...
    "client_cert": "/home/user/.certs/grafana.pem"
  },
  ...
}
```

* **env variable:** CLIENT_CERT

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>