### PR TITLE
basic auth should not override bearer auth

### DIFF
--- a/grafana_backup/create_org.py
+++ b/grafana_backup/create_org.py
@@ -4,21 +4,18 @@ from grafana_backup.dashboardApi import get_folder_id_from_old_folder_url, creat
 
 def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
-    http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_post_headers_basic_auth = settings.get('HTTP_POST_HEADERS_BASIC_AUTH')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    basic_auth = settings.get('GRAFANA_BASIC_AUTH')
-    if basic_auth:
-        http_post_headers.update({'Authorization': 'Basic {0}'.format(basic_auth)})
-
+    if http_post_headers_basic_auth:
         with open(file_path, 'r') as f:
             data = f.read()
 
         content = json.loads(data)
 
-        result = create_org(json.dumps(content), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
-        print('create org "{0}" response status: {0}, msg: {1} \n'.format(content.get('name', ''), result[0], result[1]))
+        result = create_org(json.dumps(content), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
+        print('create org "{0}" response status: {1}, msg: {2} \n'.format(content.get('name', ''), result[0], result[1]))
     else:
         print('[ERROR] Restoring organizations needs to set GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first. \n')

--- a/grafana_backup/create_user.py
+++ b/grafana_backup/create_user.py
@@ -7,23 +7,20 @@ def main(args, settings, file_path):
     Cannot get user's password, use default password instead
     """
     grafana_url = settings.get('GRAFANA_URL')
-    http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_post_headers_basic_auth = settings.get('HTTP_POST_HEADERS_BASIC_AUTH')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
     default_password = settings.get('default_password', '00000000')
-    basic_auth = settings.get('GRAFANA_BASIC_AUTH')
-    if basic_auth:
-        http_post_headers.update({'Authorization': 'Basic {0}'.format(basic_auth)})
-
+    if http_post_headers_basic_auth:
         with open(file_path, 'r') as f:
             data = f.read()
 
         user = json.loads(data)
         user.update({'password': default_password})
 
-        result = create_user(json.dumps(user), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
+        result = create_user(json.dumps(user), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
         print('create user "{0}" response status: {1}, msg: {2} \n'.format(user.get('login', ''), result[0], result[1]))
 
         if result[0] == 200:
@@ -32,7 +29,7 @@ def main(args, settings, file_path):
                     "loginOrEmail": user.get('login', 'email'),
                     "role": org.get('role', 'Viewer')
                 }
-                result = add_user_to_org(org.get('orgId'), json.dumps(org_payload), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
+                result = add_user_to_org(org.get('orgId'), json.dumps(org_payload), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
                 print('add user "{0}" to org: {1} response status: {2}, msg: {3}'.format(user.get('login', ''), org.get('name', ''), result[0], result[1]))
     else:
         print('[ERROR] Restoring users needs to set GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first. \n')

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -74,11 +74,19 @@ def main(config_path):
     config_dict['GRAFANA_ADMIN_PASSWORD'] = ADMIN_PASSWORD
 
     if not GRAFANA_BASIC_AUTH and (ADMIN_ACCOUNT and ADMIN_PASSWORD):
-        config_dict['GRAFANA_BASIC_AUTH'] = base64.b64encode(
+        GRAFANA_BASIC_AUTH = base64.b64encode(
             "{0}:{1}".format(ADMIN_ACCOUNT, ADMIN_PASSWORD).encode('utf8')
         ).decode('utf8')
+
+    if GRAFANA_BASIC_AUTH:
+        HTTP_GET_HEADERS_BASIC_AUTH = HTTP_GET_HEADERS.copy()
+        HTTP_GET_HEADERS_BASIC_AUTH.update({'Authorization': 'Basic {0}'.format(GRAFANA_BASIC_AUTH)})
+        HTTP_POST_HEADERS_BASIC_AUTH = HTTP_POST_HEADERS.copy()
+        HTTP_POST_HEADERS_BASIC_AUTH.update({'Authorization': 'Basic {0}'.format(GRAFANA_BASIC_AUTH)})
+
     else:
-        config_dict['GRAFANA_BASIC_AUTH'] = None
+        HTTP_GET_HEADERS_BASIC_AUTH = None
+        HTTP_POST_HEADERS_BASIC_AUTH = None
 
     config_dict['TOKEN'] = TOKEN
     config_dict['SEARCH_API_LIMIT'] = SEARCH_API_LIMIT
@@ -89,6 +97,8 @@ def main(config_path):
     config_dict['EXTRA_HEADERS'] = EXTRA_HEADERS
     config_dict['HTTP_GET_HEADERS'] = HTTP_GET_HEADERS
     config_dict['HTTP_POST_HEADERS'] = HTTP_POST_HEADERS
+    config_dict['HTTP_GET_HEADERS_BASIC_AUTH'] = HTTP_GET_HEADERS_BASIC_AUTH
+    config_dict['HTTP_POST_HEADERS_BASIC_AUTH'] = HTTP_POST_HEADERS_BASIC_AUTH
     config_dict['TIMESTAMP'] = TIMESTAMP
     config_dict['AWS_S3_BUCKET_NAME'] = AWS_S3_BUCKET_NAME
     config_dict['AWS_S3_BUCKET_KEY'] = AWS_S3_BUCKET_KEY

--- a/grafana_backup/save_orgs.py
+++ b/grafana_backup/save_orgs.py
@@ -9,22 +9,20 @@ def main(args, settings):
     timestamp = settings.get('TIMESTAMP')
     limit = settings.get('SEARCH_API_LIMIT')
     grafana_url = settings.get('GRAFANA_URL')
-    http_get_headers = settings.get('HTTP_GET_HEADERS')
+    http_get_headers_basic_auth = settings.get('HTTP_GET_HEADERS_BASIC_AUTH')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
     api_version = settings.get('API_VERSION')
-    basic_auth = settings.get('GRAFANA_BASIC_AUTH')
 
     folder_path = '{0}/organizations/{1}'.format(backup_dir, timestamp)
     log_file = 'organaizations_{0}.txt'.format(timestamp)
 
-    if basic_auth:
+    if http_get_headers_basic_auth:
         if not os.path.exists(folder_path):
             os.makedirs(folder_path)
 
-        http_get_headers.update({'Authorization': 'Basic {0}'.format(basic_auth)})
-        save_orgs(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
+        save_orgs(folder_path, log_file, grafana_url, http_get_headers_basic_auth, verify_ssl, client_cert, debug)
     else:
         print('[ERROR] Backing up organizations needs to set GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first.')
         print_horizontal_line()

--- a/grafana_backup/save_users.py
+++ b/grafana_backup/save_users.py
@@ -10,23 +10,20 @@ def main(args, settings):
     timestamp = settings.get('TIMESTAMP')
     limit = settings.get('SEARCH_API_LIMIT')
     grafana_url = settings.get('GRAFANA_URL')
-    http_get_headers = settings.get('HTTP_GET_HEADERS')
+    http_get_headers_basic_auth = settings.get('HTTP_GET_HEADERS_BASIC_AUTH')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
     api_version = settings.get('API_VERSION')
 
-    basic_auth = settings.get('GRAFANA_BASIC_AUTH')
-    if basic_auth:
-        http_get_headers.update({'Authorization': 'Basic {0}'.format(basic_auth)})
-
+    if http_get_headers_basic_auth:
         folder_path = '{0}/users/{1}'.format(backup_dir, timestamp)
         log_file = 'users_{0}.txt'.format(timestamp)
 
         if not os.path.exists(folder_path):
             os.makedirs(folder_path)
 
-        save_users(folder_path, log_file, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
+        save_users(folder_path, log_file, limit, grafana_url, http_get_headers_basic_auth, verify_ssl, client_cert, debug)
     else:
         print('[ERROR] Backing up users needs to set ENV GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first. \n')
         print_horizontal_line()


### PR DESCRIPTION
Users and organizations components use basic auth and override http headers.
This causes access failures while backuping components such as datasources or alert channels because they require bearer token.