### PR TITLE
Non timestamped backups

### DIFF
--- a/grafana_backup/conf/grafanaSettings.json
+++ b/grafana_backup/conf/grafanaSettings.json
@@ -2,7 +2,9 @@
   "general": {
     "debug": true,
     "verify_ssl": true,
-    "backup_dir": "_OUTPUT_"
+    "backup_dir": "_OUTPUT_",
+    "archive":  true,
+    "timestamp_backups": true
   },
   "grafana": {
     "url": "http://localhost:3000",

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -22,6 +22,9 @@ def main(config_path):
     verify_ssl = config.get('general', {}).get('verify_ssl', False)
     client_cert = config.get('general', {}).get('client_cert', None)
     backup_dir = config.get('general', {}).get('backup_dir', '_OUTPUT_')
+    archive_output = config.get('general', {}).get('archive', True)
+    timestamp_output = config.get('general', {}).get('timestamp_backups', True)
+
     aws_s3_bucket_name = config.get('aws', {}).get('s3_bucket_name', '')
     aws_s3_bucket_key = config.get('aws', {}).get('s3_bucket_key', '')
     aws_default_region = config.get('aws', {}).get('default_region', '')
@@ -56,6 +59,14 @@ def main(config_path):
     CLIENT_CERT = os.getenv('CLIENT_CERT', client_cert)
 
     BACKUP_DIR = os.getenv('BACKUP_DIR', backup_dir)
+
+    ARCHIVE_OUTPUT = os.getenv('ARCHIVE_OUTPUT', archive_output)
+    if isinstance(ARCHIVE_OUTPUT, str):
+        ARCHIVE_OUTPUT = json.loads(ARCHIVE_OUTPUT.lower())  # convert environment variable string to bool
+
+    TIMESTAMP_OUTPUT = os.getenv('TIMESTAMP_OUTPUT', timestamp_output)
+    if isinstance(TIMESTAMP_OUTPUT, str):
+        TIMESTAMP_OUTPUT = json.loads(TIMESTAMP_OUTPUT.lower())  # convert environment variable string to bool
 
     EXTRA_HEADERS = dict(
         h.split(':') for h in os.getenv('GRAFANA_HEADERS', '').split(',') if 'GRAFANA_HEADERS' in os.environ)
@@ -94,6 +105,8 @@ def main(config_path):
     config_dict['VERIFY_SSL'] = VERIFY_SSL
     config_dict['CLIENT_CERT'] = CLIENT_CERT
     config_dict['BACKUP_DIR'] = BACKUP_DIR
+    config_dict['ARCHIVE_OUTPUT'] = ARCHIVE_OUTPUT
+    config_dict['TIMESTAMP_OUTPUT'] = TIMESTAMP_OUTPUT
     config_dict['EXTRA_HEADERS'] = EXTRA_HEADERS
     config_dict['HTTP_GET_HEADERS'] = HTTP_GET_HEADERS
     config_dict['HTTP_POST_HEADERS'] = HTTP_POST_HEADERS

--- a/grafana_backup/save.py
+++ b/grafana_backup/save.py
@@ -33,11 +33,16 @@ def main(args, settings):
     settings.update({'API_VERSION': api_version})
 
     if settings.get('TIMESTAMP_OUTPUT') == False:
-        ## If we are not timestamping outputs, we should delete any existing output files before generating new ones
+        # If we are not timestamping outputs, we should delete any existing output files before generating new ones
+        # However we don't want to just delete the whole directory since there may be, e.g. a .git directory in there
         backup_dir = settings.get('BACKUP_DIR')
-        if path.exists(backup_dir):
-            print("{0} exists - deleting before creating new non-timestamped backup.".format(backup_dir))
-            shutil.rmtree(backup_dir)
+        print("{0} exists - deleting contents before creating new non-timestamped backup.".format(backup_dir))
+        # Special-case /alert_channels vs alert-channels in the backup_functions list
+        if path.exists(backup_dir + '/alert_channels' ):
+            shutil.rmtree(backup_dir + '/alert_channels')
+        for subdir in backup_functions.keys():
+            if path.exists(backup_dir + '/' + subdir ):
+                shutil.rmtree(backup_dir + '/' + subdir)
 
     if arg_components:
         arg_components_list = arg_components.split(',')

--- a/grafana_backup/save_alert_channels.py
+++ b/grafana_backup/save_alert_channels.py
@@ -6,6 +6,7 @@ from grafana_backup.commons import to_python2_and_3_compatible_string, print_hor
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
@@ -13,8 +14,12 @@ def main(args, settings):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    folder_path = '{0}/alert_channels/{1}'.format(backup_dir, timestamp)
-    log_file = 'alert_channels_{0}.txt'.format(timestamp)
+    if timestamp_output:
+        folder_path = '{0}/alert_channels/{1}'.format(backup_dir, timestamp)
+        log_file = 'alert_channels_{0}.txt'.format(timestamp)
+    else:
+        folder_path = '{0}/alert_channels'.format(backup_dir)
+        log_file = 'alert_channels.txt'
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)

--- a/grafana_backup/save_dashboards.py
+++ b/grafana_backup/save_dashboards.py
@@ -6,6 +6,7 @@ from grafana_backup.commons import to_python2_and_3_compatible_string, print_hor
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     limit = settings.get('SEARCH_API_LIMIT')
     grafana_url = settings.get('GRAFANA_URL')
@@ -15,8 +16,12 @@ def main(args, settings):
     debug = settings.get('DEBUG')
     api_version = settings.get('API_VERSION')
 
-    folder_path = '{0}/dashboards/{1}'.format(backup_dir, timestamp)
-    log_file = 'dashboards_{0}.txt'.format(timestamp)
+    if timestamp_output:
+        folder_path = '{0}/dashboards/{1}'.format(backup_dir, timestamp)
+        log_file = 'dashboards_{0}.txt'.format(timestamp)
+    else:
+        folder_path = '{0}/dashboards'.format(backup_dir)
+        log_file = 'dashboards.txt'
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)

--- a/grafana_backup/save_datasources.py
+++ b/grafana_backup/save_datasources.py
@@ -6,6 +6,7 @@ from grafana_backup.commons import print_horizontal_line
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
@@ -13,8 +14,12 @@ def main(args, settings):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    folder_path = '{0}/datasources/{1}'.format(backup_dir, timestamp)
-    log_file = 'datasources_{0}.txt'.format(timestamp)
+    if timestamp_output:
+        folder_path = '{0}/datasources/{1}'.format(backup_dir, timestamp)
+        log_file = 'datasources_{0}.txt'.format(timestamp)
+    else:
+        folder_path = '{0}/datasources'.format(backup_dir)
+        log_file = 'datasources.txt'
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)

--- a/grafana_backup/save_folders.py
+++ b/grafana_backup/save_folders.py
@@ -6,6 +6,7 @@ from grafana_backup.commons import to_python2_and_3_compatible_string, print_hor
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     grafana_url = settings.get('GRAFANA_URL')
     http_get_headers = settings.get('HTTP_GET_HEADERS')
@@ -13,8 +14,12 @@ def main(args, settings):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    folder_path = '{0}/folders/{1}'.format(backup_dir, timestamp)
-    log_file = 'folders_{0}.txt'.format(timestamp)
+    if timestamp_output:
+        folder_path = '{0}/folders/{1}'.format(backup_dir, timestamp)
+        log_file = 'folders_{0}.txt'.format(timestamp)
+    else:
+        folder_path = '{0}/folders'.format(backup_dir)
+        log_file = 'folders.txt'
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)

--- a/grafana_backup/save_orgs.py
+++ b/grafana_backup/save_orgs.py
@@ -6,6 +6,7 @@ from grafana_backup.commons import to_python2_and_3_compatible_string, print_hor
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     limit = settings.get('SEARCH_API_LIMIT')
     grafana_url = settings.get('GRAFANA_URL')
@@ -15,8 +16,12 @@ def main(args, settings):
     debug = settings.get('DEBUG')
     api_version = settings.get('API_VERSION')
 
-    folder_path = '{0}/organizations/{1}'.format(backup_dir, timestamp)
-    log_file = 'organaizations_{0}.txt'.format(timestamp)
+    if timestamp_output:
+        folder_path = '{0}/organizations/{1}'.format(backup_dir, timestamp)
+        log_file = 'organaizations_{0}.txt'.format(timestamp)
+    else:
+        folder_path = '{0}/organizations'.format(backup_dir)
+        log_file = 'organaizations.txt'
 
     if http_get_headers_basic_auth:
         if not os.path.exists(folder_path):

--- a/grafana_backup/save_users.py
+++ b/grafana_backup/save_users.py
@@ -7,6 +7,7 @@ from grafana_backup.commons import to_python2_and_3_compatible_string, print_hor
 
 def main(args, settings):
     backup_dir = settings.get('BACKUP_DIR')
+    timestamp_output = settings.get('TIMESTAMP_OUTPUT')
     timestamp = settings.get('TIMESTAMP')
     limit = settings.get('SEARCH_API_LIMIT')
     grafana_url = settings.get('GRAFANA_URL')
@@ -17,8 +18,12 @@ def main(args, settings):
     api_version = settings.get('API_VERSION')
 
     if http_get_headers_basic_auth:
-        folder_path = '{0}/users/{1}'.format(backup_dir, timestamp)
-        log_file = 'users_{0}.txt'.format(timestamp)
+        if timestamp_output:
+            folder_path = '{0}/users/{1}'.format(backup_dir, timestamp)
+            log_file = 'users_{0}.txt'.format(timestamp)
+        else:
+            folder_path = '{0}/users'.format(backup_dir)
+            log_file = 'users.txt'
 
         if not os.path.exists(folder_path):
             os.makedirs(folder_path)

--- a/restore_grafana.sh
+++ b/restore_grafana.sh
@@ -7,11 +7,11 @@ trap 'echo -ne "\n:::\n:::\tCaught signal, exiting at line $LINENO, while runnin
 archive_file="$1"
 settings_file="${2:-grafanaSettings.json}"
 
-if [[ ! -f "${archive_file}" || ! -f "${settings_file}" ]]; then
+if [[ (! -f "${archive_file}" && ! -d "${archive_file}" ) || ! -f "${settings_file}" ]]; then
 	echo "Usage:"
 	echo -e "\t$0 <path_to_archive_file> <path_to_settings_file>"
 	echo -e "\te.g. $0 '_OUTPUT_/2019-05-13T11-04-33.tar.gz' '/path/to/grafanaSettings.json'"
 	exit 1
 fi
 
-python -m grafana_backup.cli --config $settings_file restore $archive_file
+python3 -m grafana_backup.cli --config $settings_file restore $archive_file


### PR DESCRIPTION
This adds the ability to not tar the backup and to not name the directories or log files with a timestamp.

If the backup directories are being checked in to a version control repository you want each backup to produce files and directories with the same names.  The default behaviour continues to be the safest, which timestamps and archives each new backup.