### PR TITLE
dashboardApi/auth_check: verify against organization

### DIFF
--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -9,7 +9,7 @@ def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
 
 
 def auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
-    url = '{0}/api/auth/keys'.format(grafana_url)
+    url = '{0}/api/org'.format(grafana_url)
     print("grafana auth check: {0}".format(url))
     return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 


### PR DESCRIPTION
- api keys endpoint require administrative rights, which
  we might not want to grant to backup users
- hence, verify authentication against the org endpoint.