### PR TITLE
[Feature] add AWS_ENDPOINT_URL config option

### DIFF
--- a/grafana_backup/constants.py
+++ b/grafana_backup/constants.py
@@ -1,6 +1,5 @@
 import os
 
-
 PKG_NAME = 'grafana-backup'
-PKG_VERSION = '1.1.3'
+PKG_VERSION = '1.1.4'
 JSON_CONFIG_PATH = '{0}/.grafana-backup.json'.format(os.environ['HOME'])

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -1,8 +1,10 @@
 import base64
-
-from grafana_backup.commons import load_config, to_python2_and_3_compatible_string
+import json
+import os
 from datetime import datetime
-import os, json
+
+from grafana_backup.commons import (load_config,
+                                    to_python2_and_3_compatible_string)
 
 
 def main(config_path):
@@ -28,6 +30,7 @@ def main(config_path):
     aws_default_region = config.get('aws', {}).get('default_region', '')
     aws_access_key_id = config.get('aws', {}).get('access_key_id', '')
     aws_secret_access_key = config.get('aws', {}).get('secret_access_key', '')
+    aws_endpoint_url = config.get('aws', {}).get('endpoint_url', None)
 
     admin_account = config.get('grafana', {}).get('admin_account', '')
     admin_password = config.get('grafana', {}).get('admin_password', '')
@@ -41,6 +44,7 @@ def main(config_path):
     AWS_DEFAULT_REGION = os.getenv('AWS_DEFAULT_REGION', aws_default_region)
     AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', aws_access_key_id)
     AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', aws_secret_access_key)
+    AWS_ENDPOINT_URL = os.getenv('AWS_ENDPOINT_URL', aws_endpoint_url)
 
     ADMIN_ACCOUNT = os.getenv('GRAFANA_ADMIN_ACCOUNT', admin_account)
     ADMIN_PASSWORD = os.getenv('GRAFANA_ADMIN_PASSWORD', admin_password)
@@ -111,5 +115,6 @@ def main(config_path):
     config_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
     config_dict['AWS_ACCESS_KEY_ID'] = AWS_ACCESS_KEY_ID
     config_dict['AWS_SECRET_ACCESS_KEY'] = AWS_SECRET_ACCESS_KEY
+    config_dict['AWS_ENDPOINT_URL'] = AWS_ENDPOINT_URL
 
     return config_dict

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -10,6 +10,7 @@ def main(args, settings):
     aws_default_region = settings.get('AWS_DEFAULT_REGION')
     aws_access_key_id = settings.get('AWS_ACCESS_KEY_ID')
     aws_secret_access_key = settings.get('AWS_SECRET_ACCESS_KEY')
+    aws_endpoint_url = settings.get('AWS_ENDPOINT_URL')
 
     session = boto3.Session(
         aws_access_key_id=aws_access_key_id,
@@ -17,7 +18,10 @@ def main(args, settings):
         region_name=aws_default_region
     )
 
-    s3 = session.resource('s3')
+    s3 = session.resource(
+        service_name='s3',
+        endpoint_url=aws_endpoint_url
+    )
 
     s3_object = s3.Object(aws_s3_bucket_name, '{0}/{1}'.format(aws_s3_bucket_key, arg_archive_file))
 

--- a/grafana_backup/s3_upload.py
+++ b/grafana_backup/s3_upload.py
@@ -8,6 +8,7 @@ def main(args, settings):
     aws_default_region = settings.get('AWS_DEFAULT_REGION')
     aws_access_key_id = settings.get('AWS_ACCESS_KEY_ID')
     aws_secret_access_key = settings.get('AWS_SECRET_ACCESS_KEY')
+    aws_endpoint_url = settings.get('AWS_ENDPOINT_URL')
 
     backup_dir = settings.get('BACKUP_DIR')
     timestamp = settings.get('TIMESTAMP')
@@ -21,7 +22,10 @@ def main(args, settings):
         region_name=aws_default_region
     )
 
-    s3 = session.resource('s3')
+    s3 = session.resource(
+        service_name='s3',
+        endpoint_url=aws_endpoint_url
+    )
 
     s3_object = s3.Object(aws_s3_bucket_name, '{0}/{1}'.format(aws_s3_bucket_key, s3_file_name))
 


### PR DESCRIPTION
This PR adds an additional config option to specify the AWS endpoint URL.
It's pretty handy when one does not upload to AWS S3, but another S3 compatible endpoint (like MinIO).
If the endpoint URL is `None`, boto3 will generate it automatically.