### PR TITLE
remove useless cleanup metod within tempfile

### DIFF
--- a/grafana_backup/restore.py
+++ b/grafana_backup/restore.py
@@ -53,7 +53,6 @@ def main(args, settings):
             tar.extractall(tmpdir)
             tar.close()
             restore_components(args, settings, restore_functions, tmpdir)
-            tmpdir.cleanup()
     else:
         tmpdir = tempfile.mkdtemp()
         tar.extractall(tmpdir)


### PR DESCRIPTION
Hi @ysde , I got error when attempting restore, it was:

```
Traceback (most recent call last):
2020-11-24T07:01:58.032776785Z   File "/usr/bin/grafana-backup", line 11, in <module>
2020-11-24T07:01:58.032780933Z     load_entry_point('grafana-backup==1.1.4', 'console_scripts', 'grafana-backup')()
2020-11-24T07:01:58.032783690Z   File "/usr/lib/python3.8/site-packages/grafana_backup/cli.py", line 46, in main
2020-11-24T07:01:58.032786498Z     restore(args, settings)
2020-11-24T07:01:58.032789103Z   File "/usr/lib/python3.8/site-packages/grafana_backup/restore.py", line 56, in main
2020-11-24T07:01:58.032792109Z     tmpdir.cleanup()
2020-11-24T07:01:58.032794835Z AttributeError: 'str' object has no attribute 'cleanup'
```
and after searching found that 
```
cleanup() method is something USELESS INSIDE CONTEXT MANAGER with, since it's a method of tempfile.TemporaryDirectory() - which, if used in the context manager, returns a string ! (not the object itself). On top of that tempfile.TemporaryDirectory.cleanup() does not just "clean" its contents it also removes the directory itself!
```
so this PR simply removed it