### PR TITLE
multi arch docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk
 WORKDIR /opt/grafana-backup-tool
 ADD . /opt/grafana-backup-tool
 
+RUN chmod -R a+r /opt/grafana-backup-tool \
+ && find /opt/grafana-backup-tool -type d -print0 | xargs -0 chmod a+rx
+
 RUN pip3 --no-cache-dir install .
 
 RUN chown -R 1337:1337 /opt/grafana-backup-tool

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
-FULLTAG=alpinebased:grafana-backup
+
+DOCKER_REPO ?= ysde
+DOCKER_NAME := grafana-backup
+DOCKER_TAG ?= latest
+PLATFORMS ?= linux/amd64,linux/arm/v7
+
+FULLTAG = $(DOCKER_REPO)/$(DOCKER_NAME):$(DOCKER_TAG)
+
 DOCKERFILE=Dockerfile
+
 all: build
 
 build:
 	docker build -t $(FULLTAG) -f $(DOCKERFILE) .
+
 push: build
 	docker push $(FULLTAG)
+
+
+buildx_and_push:
+	docker buildx build \
+		--output type=image,name=$(DOCKER_REPO)/$(DOCKER_NAME),push=true \
+	 	--platform linux/amd64,linux/arm/v7 \
+		--tag $(FULLTAG) \
+	 	--file $(DOCKERFILE) .

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ sudo chown 1337:1337 /tmp/backup
 ```
 
 ```
-docker run --rm --name grafana-backup-tool \
+docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
            -e GRAFANA_TOKEN={YOUR_GRAFANA_TOKEN} \
            -e GRAFANA_URL={YOUR_GRAFANA_URL} \
            -e GRAFANA_ADMIN_ACCOUNT={YOUR_GRAFANA_ADMIN_ACCOUNT} \
@@ -131,7 +131,7 @@ docker run --rm --name grafana-backup-tool \
 ***Example:***
 
 ```
-docker run --rm --name grafana-backup-tool \
+docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
            -e GRAFANA_TOKEN="eyJrIjoiNGZqTDEyeXNaY0RsMXNhbkNTSnlKN2M3bE1VeHdqVTEiLCJuIjoiZ3JhZmFuYS1iYWNrdXAiLCJpZCI6MX0=" \
            -e GRAFANA_URL=http://192.168.0.79:3000 \
            -e GRAFANA_ADMIN_ACCOUNT=admin \
@@ -150,7 +150,7 @@ docker run --rm --name grafana-backup-tool \
 ### Restore
 
 ```
-docker run --rm --name grafana-backup-tool \
+docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
            -e GRAFANA_TOKEN={YOUR_GRAFANA_TOKEN} \
            -e GRAFANA_URL={YOUR_GRAFANA_URL} \
            -e GRAFANA_ADMIN_ACCOUNT={YOUR_GRAFANA_ADMIN_ACCOUNT} \
@@ -165,7 +165,7 @@ docker run --rm --name grafana-backup-tool \
 ***Example:***
 
 ```
-docker run --rm --name grafana-backup-tool \
+docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
            -e GRAFANA_TOKEN="eyJrIjoiNGZqTDEyeXNaY0RsMXNhbkNTSnlKN2M3bE1VeHdqVTEiLCJuIjoiZ3JhZmFuYS1iYWNrdXAiLCJpZCI6MX0=" \
            -e GRAFANA_URL=http://192.168.0.79:3000 \
            -e GRAFANA_ADMIN_ACCOUNT=admin \


### PR DESCRIPTION
Adds a Makefile target to build images for amd64 and ARMv7 using docker buildx.  I'm using this to generate an image usable on a Raspberry Pi 3.

The PR also sets file permissions in the docker image so that the container can be executed with any uid -- important so that we can access mounted host volumes with appropriate uid/gid.