### PR TITLE
Add error handling for nonexistent key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.1.9] - 2021-05-26
+
+### Added
+
+### Changed
+- #92 better error message when the user specifies a bad S3 key
+
+### Removed
+
+
 # [1.1.7] - 2021-01-13
 
 ### Added
@@ -28,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- #104 added python2 support to restore functions 
+- #104 added python2 support to restore functions
 - #105 add configuration attribute to set backup file name
 - #112 changed restore_functions to ordered dict
 - #113 [Fixed] Dashboards with same name in different folders not restored
@@ -52,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - #83 Fix tarfile options for python2
-- #64 Remove empty folders when backup file (.tar.gz) created.  
+- #64 Remove empty folders when backup file (.tar.gz) created.
 
 
 # [1.1.2] - 2020-08-14

--- a/grafana_backup/constants.py
+++ b/grafana_backup/constants.py
@@ -1,5 +1,11 @@
 import os
 
-PKG_NAME = 'grafana-backup'
-PKG_VERSION = '1.1.8'
-JSON_CONFIG_PATH = '{0}/.grafana-backup.json'.format(os.environ['HOME'])
+
+if os.name == "nt":
+    homedir = os.environ["HOMEPATH"]
+else:
+    homedir = os.environ["HOME"]
+
+PKG_NAME = "grafana-backup"
+PKG_VERSION = "1.1.8"
+JSON_CONFIG_PATH = "{0}/.grafana-backup.json".format(homedir)

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -4,10 +4,6 @@ from botocore.exceptions import NoCredentialsError, ClientError
 
 def main(args, settings):
     arg_archive_file = args.get("<archive_file>", None)
-    if not arg_archive_file:
-        print("No archive file specified")
-        return False
-
     aws_s3_bucket_name = settings.get("AWS_S3_BUCKET_NAME")
     aws_s3_bucket_key = settings.get("AWS_S3_BUCKET_KEY")
     aws_default_region = settings.get("AWS_DEFAULT_REGION")

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -1,34 +1,38 @@
 import boto3
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import NoCredentialsError, ClientError
 
 
 def main(args, settings):
-    arg_archive_file = args.get('<archive_file>', None)
+    arg_archive_file = args.get("<archive_file>", None)
+    if not arg_archive_file:
+        print("No archive file specified")
+        return False
 
-    aws_s3_bucket_name = settings.get('AWS_S3_BUCKET_NAME')
-    aws_s3_bucket_key = settings.get('AWS_S3_BUCKET_KEY')
-    aws_default_region = settings.get('AWS_DEFAULT_REGION')
-    aws_access_key_id = settings.get('AWS_ACCESS_KEY_ID')
-    aws_secret_access_key = settings.get('AWS_SECRET_ACCESS_KEY')
-    aws_endpoint_url = settings.get('AWS_ENDPOINT_URL')
+    aws_s3_bucket_name = settings.get("AWS_S3_BUCKET_NAME")
+    aws_s3_bucket_key = settings.get("AWS_S3_BUCKET_KEY")
+    aws_default_region = settings.get("AWS_DEFAULT_REGION")
+    aws_access_key_id = settings.get("AWS_ACCESS_KEY_ID")
+    aws_secret_access_key = settings.get("AWS_SECRET_ACCESS_KEY")
+    aws_endpoint_url = settings.get("AWS_ENDPOINT_URL")
 
     session = boto3.Session(
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        region_name=aws_default_region
+        aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key, region_name=aws_default_region
     )
 
-    s3 = session.resource(
-        service_name='s3',
-        endpoint_url=aws_endpoint_url
-    )
+    s3 = session.resource(service_name="s3", endpoint_url=aws_endpoint_url)
 
-    s3_object = s3.Object(aws_s3_bucket_name, '{0}/{1}'.format(aws_s3_bucket_key, arg_archive_file))
+    s3_path = "{0}/{1}".format(aws_s3_bucket_key, arg_archive_file)
+    s3_object = s3.Object(aws_s3_bucket_name, s3_path)
 
     try:
         # .read() left off on purpose, tarfile.open() takes care of that part
-        s3_data = s3_object.get()['Body']
+        s3_data = s3_object.get()["Body"]
         print("Download from S3 was successful")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            print(f"Error: Key {s3_path} does not exist in bucket {aws_s3_bucket_name}")
+            return False
+        raise e
     except NoCredentialsError:
         print("Credentials not available")
         return False


### PR DESCRIPTION
I tested this with:

```
from s3_download import main
from grafana_backup.grafanaSettings import main as conf

settings = conf("/Users/tommycarpenter/.grafana-backup.json")

main({}, settings)
main({"<archive_file>": "DOES NOT EXIST"}, settings)
main({"<archive_file>": "202105261617.tar.gz"}, settings)
```

which prints

```
No archive file specified
Error: Key grafana-backup/DOES NOT EXIST does not exist in bucket [REDACTED]
Download from S3 was successful
```

RE the `'` to `"`; I use https://github.com/psf/black which auto-reformatted here

Since there are no tests in this repo..