### PR TITLE
Update main organization instead of creating a new one

### DIFF
--- a/grafana_backup/create_org.py
+++ b/grafana_backup/create_org.py
@@ -1,5 +1,5 @@
 import json
-from grafana_backup.dashboardApi import get_folder_id_from_old_folder_url, create_org
+from grafana_backup.dashboardApi import get_folder_id_from_old_folder_url, create_org, update_org
 
 
 def main(args, settings, file_path):
@@ -14,8 +14,13 @@ def main(args, settings, file_path):
             data = f.read()
 
         content = json.loads(data)
+        org_id = content["id"]
 
-        result = create_org(json.dumps(content), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
-        print('create org "{0}" response status: {1}, msg: {2} \n'.format(content.get('name', ''), result[0], result[1]))
+        if (org_id == 1):
+            result = update_org(org_id, json.dumps(content), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
+            print('update org "{0}" response status: {1}, msg: {2} \n'.format(content.get('name', ''), result[0], result[1]))
+        else:
+            result = create_org(json.dumps(content), grafana_url, http_post_headers_basic_auth, verify_ssl, client_cert, debug)
+            print('create org "{0}" response status: {1}, msg: {2} \n'.format(content.get('name', ''), result[0], result[1]))
     else:
         print('[ERROR] Restoring organizations needs to set GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first. \n')

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -159,6 +159,10 @@ def create_org(payload, grafana_url, http_post_headers, verify_ssl, client_cert,
     return send_grafana_post('{0}/api/orgs'.format(grafana_url), payload, http_post_headers, verify_ssl, client_cert,
                              debug)
 
+def update_org(id, payload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
+    return send_grafana_put('{0}/api/orgs/{1}'.format(grafana_url, id), payload, http_post_headers, verify_ssl, client_cert,
+                             debug)
+
 
 def search_users(page, limit, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     return send_grafana_get('{0}/api/users?perpage={1}&page={2}'.format(grafana_url, limit, page),
@@ -191,6 +195,12 @@ def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
 
 def send_grafana_post(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):
     r = requests.post(url, headers=http_post_headers, data=json_payload, verify=verify_ssl, cert=client_cert)
+    if debug:
+        log_response(r)
+    return (r.status_code, r.json())
+
+def send_grafana_put(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):
+    r = requests.put(url, headers=http_post_headers, data=json_payload, verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
     return (r.status_code, r.json())


### PR DESCRIPTION
Hi,

currently, all backed-up organizations get added as new ones.
However, when creating a new Grafana instance, an organization with id `1` and name `Main Org.` is automatically created.
Which is then either duplicated, or - in case you renamed your main org - you have the new `Main Org.` and then, with a changed id, your original organization with id `1`

The Grafana API allows updating of existing organizations via `PUT` request to `/api/orgs/id`.

This PR uses this updating API for the organization with id `1` but still creates all remaining backed-up organizations.

Open points/to discuss:
* Should we check if the new Grafana instance has an organization with id `1`? Theoretically someone could have deleted the organization with id `1` before running the restore
* For `PUT` requests the same basic auth headers work as for `POST` requests. Should we rename the settings to HTTP_POSTPUT_* to make it more clear? In this PR I just used the existing `POST` setting for the put request