### PR TITLE
(feat): enable/disable api health check not supported by amazon manag…

### DIFF
--- a/grafana_backup/api_checks.py
+++ b/grafana_backup/api_checks.py
@@ -8,10 +8,12 @@ def main(settings):
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
+    api_health_check = settings.get('API_HEALTH_CHECK')
 
-    (status, json_resp) = health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
-    if not status == 200:
-        return (status, json_resp, None, None, None)
+    if api_health_check:
+        (status, json_resp) = health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
+        if not status == 200:
+            return (status, json_resp, None, None, None)
 
     (status, json_resp) = auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     if not status == 200:

--- a/grafana_backup/conf/grafanaSettings.json
+++ b/grafana_backup/conf/grafanaSettings.json
@@ -2,6 +2,7 @@
   "general": {
     "debug": true,
     "verify_ssl": true,
+    "api_health_check": true,
     "backup_dir": "_OUTPUT_",
     "backup_file_format": "%Y%m%d%H%M",
     "pretty_print": false

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -19,6 +19,7 @@ def main(config_path):
     grafana_search_api_limit = config.get('grafana', {}).get('search_api_limit', 5000)
 
     debug = config.get('general', {}).get('debug', True)
+    api_health_check = config.get('general', {}).get('api_health_check', True)
     verify_ssl = config.get('general', {}).get('verify_ssl', False)
     client_cert = config.get('general', {}).get('client_cert', None)
     backup_dir = config.get('general', {}).get('backup_dir', '_OUTPUT_')
@@ -73,6 +74,10 @@ def main(config_path):
     if isinstance(VERIFY_SSL, str):
         VERIFY_SSL = json.loads(VERIFY_SSL.lower())  # convert environment variable string to bool
 
+    API_HEALTH_CHECK = os.getenv('API_HEALTH_CHECK', api_health_check)
+    if isinstance(API_HEALTH_CHECK, str):
+        API_HEALTH_CHECK = json.loads(API_HEALTH_CHECK.lower())  # convert environment variable string to bool
+
     CLIENT_CERT = os.getenv('CLIENT_CERT', client_cert)
 
     BACKUP_DIR = os.getenv('BACKUP_DIR', backup_dir)
@@ -118,6 +123,7 @@ def main(config_path):
     config_dict['TOKEN'] = TOKEN
     config_dict['SEARCH_API_LIMIT'] = SEARCH_API_LIMIT
     config_dict['DEBUG'] = DEBUG
+    config_dict['API_HEALTH_CHECK'] = API_HEALTH_CHECK
     config_dict['VERIFY_SSL'] = VERIFY_SSL
     config_dict['CLIENT_CERT'] = CLIENT_CERT
     config_dict['BACKUP_DIR'] = BACKUP_DIR


### PR DESCRIPTION
…ed grafana

Amazon Managed Grafana does not support api health checks.
Therefore, the backup tool fails with the following error:
[DEBUG] resp body: Bad Request: Not allowed.
This new parameter in the configuration allows us to enable/disable the api health check in order to use the tool.