### PR TITLE
Require only necessary permissions when saving backup to GCS bucket

### DIFF
--- a/grafana_backup/gcs_upload.py
+++ b/grafana_backup/gcs_upload.py
@@ -13,7 +13,7 @@ def main(args, settings):
     archive_file = '{0}/{1}'.format(backup_dir, gcs_file_name)
 
     try:
-        bucket = storage_client.get_bucket(bucket_name)
+        bucket = storage_client.bucket(bucket_name)
 
         blob = bucket.blob(gcs_file_name)
         blob.upload_from_filename(archive_file)


### PR DESCRIPTION
Currently when save to GCS:
```
Permission denied: 403 GET https://storage.googleapis.com/storage/v1/b/bucket-name-redacted?projection=noAcl&prettyPrint=false: sa-name-redacted@project-redacted.iam.
gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket., please grant `Storage Admin` to service account you used
```
This is caused by `get_bucket()` call used instead of `bucket()`. Latter doesn't make actual API call so its permissions are only scoped to a bucket, not to a project. 