### PR TITLE
Fix restoring library elements that have more than one folder

### DIFF
--- a/grafana_backup/create_library_element.py
+++ b/grafana_backup/create_library_element.py
@@ -15,9 +15,24 @@ def main(args, settings, file_path):
     # Library Elements can only be created referencing a folder id. However, this folder id is not unique across Grafana
     # instances. Therefore, we need to first find the folder id by the given folder uid.
     library_element = json.loads(data)
-    folder_uid = library_element['meta']['folderUid']
-    folder_id = get_folder(folder_uid, grafana_url, http_post_headers, verify_ssl, client_cert, debug)[1]['id']
-    library_element['folderId'] = folder_id
-    result = create_library_element(json.dumps(library_element), grafana_url, http_post_headers, verify_ssl,
-                                    client_cert, debug)
-    print("create library_elements: {0}, status: {1}, msg: {2}".format(library_element['name'], result[0], result[1]))
+    folder_uid = library_element["meta"]["folderUid"]
+    folder_id_response = get_folder(
+        folder_uid, grafana_url, http_post_headers, verify_ssl, client_cert, debug
+    )[1]
+    if isinstance(folder_id_response, list):
+        library_element["folderUid"] = folder_id_response[0]['uid']
+    else:
+        library_element["folderUid"] = folder_id_response['uid']
+    result = create_library_element(
+        json.dumps(library_element),
+        grafana_url,
+        http_post_headers,
+        verify_ssl,
+        client_cert,
+        debug,
+    )
+    print(
+        "create library_elements: {0}, status: {1}, msg: {2}".format(
+            library_element["name"], result[0], result[1]
+        )
+    )


### PR DESCRIPTION
If multiple folders are present on a library element (e.g. if used in multiple dashboards in different folders), the API returns multiple folder ID responses. Handle that by recreating the element with the first folder.

Also, switch from using folderId to folderUid (folderId has been deprecated since grafana v9).

I unfortunately couldn't get my editor to not re-format the file with `black` in the hurry I was in today. If this is undesired, let me know and I'll fix it later.