### PR TITLE
Fixed GCP bucket upload example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
 ***GCS Example:*** Set GCS configurations in `-e` or `grafanaSettings.json`([example](https://github.com/ysde/grafana-backup-tool/blob/master/examples/grafana-backup.example.json))
 ```
 		   -e GCS_BUCKET_NAME="bucket-name" \
+		   -e GCLOUD_PROJECT="gcp-project-name" \
 		   -e GOOGLE_APPLICATION_CREDENTIALS="credential-file-path"
 ```
 


### PR DESCRIPTION
Update documentation to include GCLOUD_PROJECT environment variable. 
Without this variable gcs_upload.py fails to instantiate storage.Client()

Example error:
OSError: Project was not passed and could not be determined from the environment.