### PR TITLE
Only support alert rules if grafana is above version 9.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The aim of this tool is to:
 * Dashboard (contains Alert)
 * Datasource
 * Alert Channel
+* Alert Rules (Supported in version 9.4.0 of grafana and up.)
 * Teams
 * Team Members (Needs Basic Authentication (username and password, see [grafana doc](https://grafana.com/docs/grafana/latest/http_api/org/#admin-organizations-api))
     * You need to set `Admin's account and password` in `grafanaSettings.json`, or set the base64 encoded `admin account and password` in ENV `GRAFANA_BASIC_AUTH`. E.g `export GRAFANA_BASIC_AUTH=YWRtaW46YWRtaW4=`

--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -1,5 +1,6 @@
 import json
-from grafana_backup.dashboardApi import create_alert_rule
+from grafana_backup.dashboardApi import create_alert_rule, get_grafana_version
+from packaging import version
 
 
 def main(args, settings, file_path):
@@ -12,6 +13,12 @@ def main(args, settings, file_path):
     with open(file_path, 'r') as f:
         data = f.read()
 
-    alert_rule = json.loads(data)
-    result = create_alert_rule(json.dumps(alert_rule), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
-    print("create alert rule: {0}, status: {1}, msg: {2}".format(alert_rule['title'], result[0], result[1]))
+    grafana_version = get_grafana_version(grafana_url)
+    minimum_version = version.parse('9.4.0')
+
+    if minimum_version <= grafana_version:
+        alert_rule = json.loads(data)
+        result = create_alert_rule(json.dumps(alert_rule), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
+        print("create alert rule: {0}, status: {1}, msg: {2}".format(alert_rule['title'], result[0], result[1]))
+    else:
+        print("Unable to create alert rules, requires Grafana version {0} or above. Current version is {1}".format(minimum_version, grafana_version))

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -3,6 +3,7 @@ import json
 import requests
 import sys
 from grafana_backup.commons import log_response, to_python2_and_3_compatible_string
+from packaging import version
 
 
 def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
@@ -433,6 +434,12 @@ def add_user_to_org(org_id, payload, grafana_url, http_post_headers, verify_ssl,
     return send_grafana_post('{0}/api/orgs/{1}/users'.format(grafana_url, org_id), payload, http_post_headers, verify_ssl, client_cert,
                              debug)
 
+def get_grafana_version(grafana_url):
+    r = requests.get('{0}/api/health'.format(grafana_url))
+    if r.status_code == 200:
+        return version.parse(r.json()['version'])
+    else:
+        raise Exception("Unable to get version, returned response: {0}".format(r.status_code))
 
 def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
     r = requests.get(url, headers=http_get_headers, verify=verify_ssl, cert=client_cert)

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -1,6 +1,7 @@
 import os
-from grafana_backup.dashboardApi import search_alert_rules, get_alert_rule
+from grafana_backup.dashboardApi import search_alert_rules, get_alert_rule, get_grafana_version
 from grafana_backup.commons import to_python2_and_3_compatible_string, print_horizontal_line, save_json
+from packaging import version
 
 
 def main(args, settings):
@@ -15,10 +16,17 @@ def main(args, settings):
     folder_path = '{0}/alert_rules/{1}'.format(backup_dir, timestamp)
     log_file = 'alert_rules_{0}.txt'.format(timestamp)
 
-    if not os.path.exists(folder_path):
-        os.makedirs(folder_path)
+    grafana_version = get_grafana_version(grafana_url)
+    minimum_version = version.parse('9.4.0')
 
-    save_alert_rules(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug, pretty_print)
+    if minimum_version <= grafana_version:
+
+        if not os.path.exists(folder_path):
+            os.makedirs(folder_path)
+
+        save_alert_rules(folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug, pretty_print)
+    else:
+        print("Unable to save alert rules, requires Grafana version {0} or above. Current version is {1}".format(minimum_version, grafana_version))
 
 
 def get_all_alert_rules_in_grafana(grafana_url, http_get_headers, verify_ssl, client_cert, debug):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ requires = [
     'boto3',
     'azure-storage-blob',
     'google-cloud-storage',
-    'influxdb'
+    'influxdb',
+    'packaging'
 ]
 
 setup(


### PR DESCRIPTION
Follow on from #201 

This ensures that it only saves and restores alert rules if grafana's version is equal to or above 9.4.0.

I have tested this by running up a docker image of the various version and trying to restore and back up from each version.

How does this look @acjohnson @michyliao @ysde 

This does add a dependency on to the packaging library, hope that's ok.