### PR TITLE
Pass verify_ssl to get_grafana_version method

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -13,7 +13,7 @@ def main(args, settings, file_path):
     with open(file_path, 'r') as f:
         data = f.read()
 
-    grafana_version = get_grafana_version(grafana_url)
+    grafana_version = get_grafana_version(grafana_url, verify_ssl)
     minimum_version = version.parse('9.4.0')
 
     if minimum_version <= grafana_version:

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -434,8 +434,8 @@ def add_user_to_org(org_id, payload, grafana_url, http_post_headers, verify_ssl,
     return send_grafana_post('{0}/api/orgs/{1}/users'.format(grafana_url, org_id), payload, http_post_headers, verify_ssl, client_cert,
                              debug)
 
-def get_grafana_version(grafana_url):
-    r = requests.get('{0}/api/health'.format(grafana_url))
+def get_grafana_version(grafana_url, verify_ssl):
+    r = requests.get('{0}/api/health'.format(grafana_url), verify=verify_ssl)
     if r.status_code == 200:
         return version.parse(r.json()['version'])
     else:

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -1,6 +1,9 @@
 import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
-import StringIO
+try:
+    import StringIO 
+except ImportError:
+    from io import StringIO 
 
 
 def main(args, settings):

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -16,7 +16,7 @@ def main(args, settings):
     folder_path = '{0}/alert_rules/{1}'.format(backup_dir, timestamp)
     log_file = 'alert_rules_{0}.txt'.format(timestamp)
 
-    grafana_version = get_grafana_version(grafana_url)
+    grafana_version = get_grafana_version(grafana_url, verify_ssl)
     minimum_version = version.parse('9.4.0')
 
     if minimum_version <= grafana_version:


### PR DESCRIPTION
When using new save alert features, we met some ssl related errors.
We are using` verify_ssl=False`. It seems that in dashboardApi.py, `get_grafana_version` method does not pass `verify_ssl` in config to `request.get()`. Is it possible that the `verify_ssl` parameter could be added to it?

Related to issue: https://github.com/ysde/grafana-backup-tool/issues/206