### PR TITLE
Update alert-rules key to match convention set in cli.py

### DIFF
--- a/grafana_backup/save.py
+++ b/grafana_backup/save.py
@@ -36,7 +36,7 @@ def main(args, settings):
                         'library-elements': save_library_elements,
                         'teams': save_teams,
                         'team-members': save_team_members,
-                        'save-alert-rules': save_alert_rules}
+                        'alert-rules': save_alert_rules}
 
     (status, json_resp, dashboard_uid_support, datasource_uid_support, paging_support) = api_checks(settings)
 


### PR DESCRIPTION
https://github.com/ysde/grafana-backup-tool/blob/master/grafana_backup/cli.py#L27-L28

Current behavior requires passing in save_alert_rules (or save-alert-rules) which is counter the established pattern and counter the documentation of components in cli.py