### PR TITLE
 add the x-disable-provenance header for create_alert_rule

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -6,6 +6,7 @@ from packaging import version
 def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_post_headers['x-disable-provenance']='*'
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -1,9 +1,6 @@
 import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
-try:
-    import StringIO 
-except ImportError:
-    from io import StringIO 
+from io import BytesIO 
 
 
 def main(args, settings):
@@ -27,7 +24,7 @@ def main(args, settings):
     try:
         # .read() left off on purpose, tarfile.open() takes care of that part
         s3_data_raw = s3_object.get()["Body"]
-        s3_data = StringIO.StringIO(s3_data_raw.read())
+        s3_data = BytesIO(s3_data_raw.read())
         print("Download from S3 was successful")
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":


### PR DESCRIPTION
Currently the `create_alert_rule` method provisions the alerting resources using the Alerting Provisioning HTTP API. Could we add   the` x-disable-provenance` header to the requests when creating alerts rules in the API.

https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/