### PR TITLE
Fix default user password

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The aim of this tool is to:
     * Or Sets this ENV of the Grafana server `GF_USERS_ALLOW_ORG_CREATE=true`. see [grafana doc](https://grafana.com/docs/grafana/latest/http_api/org/#create-organization)
 * User (Needs Basic Authentication (username and password, see [grafana doc](https://grafana.com/docs/grafana/latest/http_api/org/#admin-organizations-api))
     * You need to set `Admin's account and password` in `grafanaSettings.json`, or set the base64 encoded `admin account and password` in ENV `GRAFANA_BASIC_AUTH`. E.g `export GRAFANA_BASIC_AUTH=YWRtaW46YWRtaW4=`
-    * Grafana's api doesn't provide user's password when backing up, so the `default_password (which is in the grafanaSetting.json)` will be used when restoring.
+    * Grafana's api doesn't provide user's password when backing up, so the `default_user_password` in `grafanaSettings.json`, or in ENV `DEFAULT_USER_PASSWORD`, E.g `export DEFAULT_USER_PASSWORD=supersecret` will be used when restoring. 
 * Snapshots
 * Dashboard Versions (only backup, no restore)
 * Annotations

--- a/examples/grafana-backup.example.json
+++ b/examples/grafana-backup.example.json
@@ -8,7 +8,7 @@
     "url": "http://localhost:3000",
     "token": "{YOUR_GRAFANA_TOKEN}",
     "search_api_limit": 5000,
-    "default_password": "00000000",
+    "default_user_password": "00000000",
     "admin_account": "admin",
     "admin_password": "admin"
   },

--- a/grafana_backup/conf/grafanaSettings.json
+++ b/grafana_backup/conf/grafanaSettings.json
@@ -11,7 +11,7 @@
     "url": "http://localhost:3000",
     "token": "",
     "search_api_limit": 5000,
-    "default_password": "00000000",
+    "default_user_password": "00000000",
     "admin_account": "",
     "admin_password": ""
   }

--- a/grafana_backup/create_user.py
+++ b/grafana_backup/create_user.py
@@ -12,7 +12,7 @@ def main(args, settings, file_path):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    default_password = settings.get('default_password', '00000000')
+    default_password = settings.get('DEFAULT_USER_PASSWORD')
     if http_post_headers_basic_auth:
         with open(file_path, 'r') as f:
             data = f.read()

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -17,6 +17,7 @@ def main(config_path):
     grafana_url = config.get('grafana', {}).get('url', '')
     grafana_token = config.get('grafana', {}).get('token', '')
     grafana_search_api_limit = config.get('grafana', {}).get('search_api_limit', 5000)
+    grafana_default_user_password = config.get('grafana', {}).get('default_user_password', '00000000')
 
     debug = config.get('general', {}).get('debug', True)
     api_health_check = config.get('general', {}).get('api_health_check', True)
@@ -54,6 +55,7 @@ def main(config_path):
     GRAFANA_URL = os.getenv('GRAFANA_URL', grafana_url)
     TOKEN = os.getenv('GRAFANA_TOKEN', grafana_token)
     SEARCH_API_LIMIT = os.getenv('SEARCH_API_LIMIT', grafana_search_api_limit)
+    DEFAULT_USER_PASSWORD = os.getenv('DEFAULT_USER_PASSWORD', grafana_default_user_password)
 
     AWS_S3_BUCKET_NAME = os.getenv('AWS_S3_BUCKET_NAME', aws_s3_bucket_name)
     AWS_S3_BUCKET_KEY = os.getenv('AWS_S3_BUCKET_KEY', aws_s3_bucket_key)
@@ -134,6 +136,7 @@ def main(config_path):
         HTTP_GET_HEADERS_BASIC_AUTH = None
         HTTP_POST_HEADERS_BASIC_AUTH = None
 
+    config_dict['DEFAULT_USER_PASSWORD'] = DEFAULT_USER_PASSWORD
     config_dict['TOKEN'] = TOKEN
     config_dict['SEARCH_API_LIMIT'] = SEARCH_API_LIMIT
     config_dict['DEBUG'] = DEBUG


### PR DESCRIPTION
The default user password is always `00000000` regardless of configuration file or env, because it was not being added to the `settings` dictionary.