### PR TITLE
allow disabling auth check

### DIFF
--- a/grafana_backup/api_checks.py
+++ b/grafana_backup/api_checks.py
@@ -9,15 +9,17 @@ def main(settings):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
     api_health_check = settings.get('API_HEALTH_CHECK')
+    api_auth_check = settings.get('API_AUTH_CHECK')
 
     if api_health_check:
         (status, json_resp) = health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         if not status == 200:
             return (status, json_resp, None, None, None)
 
-    (status, json_resp) = auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
-    if not status == 200:
-        return (status, json_resp, None, None, None)
+    if api_auth_check:
+        (status, json_resp) = auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
+        if not status == 200:
+            return (status, json_resp, None, None, None)
 
     dashboard_uid_support, datasource_uid_support = uid_feature_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug)
     if isinstance(dashboard_uid_support, str):

--- a/grafana_backup/conf/grafanaSettings.json
+++ b/grafana_backup/conf/grafanaSettings.json
@@ -3,6 +3,7 @@
     "debug": true,
     "verify_ssl": true,
     "api_health_check": true,
+    "api_auth_check": true,
     "backup_dir": "_OUTPUT_",
     "backup_file_format": "%Y%m%d%H%M",
     "pretty_print": false
@@ -16,4 +17,3 @@
     "admin_password": ""
   }
 }
-

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -20,6 +20,7 @@ def main(config_path):
 
     debug = config.get('general', {}).get('debug', True)
     api_health_check = config.get('general', {}).get('api_health_check', True)
+    api_auth_check = config.get('general', {}).get('api_auth_check', True)
     verify_ssl = config.get('general', {}).get('verify_ssl', False)
     client_cert = config.get('general', {}).get('client_cert', None)
     backup_dir = config.get('general', {}).get('backup_dir', '_OUTPUT_')
@@ -92,6 +93,10 @@ def main(config_path):
     if isinstance(API_HEALTH_CHECK, str):
         API_HEALTH_CHECK = json.loads(API_HEALTH_CHECK.lower())  # convert environment variable string to bool
 
+    API_AUTH_CHECK = os.getenv('API_AUTH_CHECK', api_auth_check)
+    if isinstance(API_AUTH_CHECK, str):
+        API_AUTH_CHECK = json.loads(API_AUTH_CHECK.lower())  # convert environment variable string to bool
+
     CLIENT_CERT = os.getenv('CLIENT_CERT', client_cert)
 
     BACKUP_DIR = os.getenv('BACKUP_DIR', backup_dir)
@@ -138,6 +143,7 @@ def main(config_path):
     config_dict['SEARCH_API_LIMIT'] = SEARCH_API_LIMIT
     config_dict['DEBUG'] = DEBUG
     config_dict['API_HEALTH_CHECK'] = API_HEALTH_CHECK
+    config_dict['API_AUTH_CHECK'] = API_AUTH_CHECK
     config_dict['VERIFY_SSL'] = VERIFY_SSL
     config_dict['CLIENT_CERT'] = CLIENT_CERT
     config_dict['BACKUP_DIR'] = BACKUP_DIR


### PR DESCRIPTION
For a small but important scope of tasks Admin role is not required. For example dumping the dashboards, which is where all the knowledge is stored. I suggest the following flag to be able to disable `admin` check if needed.

use env var `API_AUTH_CHECK=false` or a corresponding config field `api_auth_check: false`