### PR TITLE
hide_version-config: add version as config/env var

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -10,11 +10,19 @@ def main(args, settings, file_path):
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
+    grafana_version_string = settings.get('GRAFANA_VERSION')
+    if grafana_version_string:
+      grafana_version = version.parse(grafana_version_string)
 
     with open(file_path, 'r') as f:
         data = f.read()
 
-    grafana_version = get_grafana_version(grafana_url, verify_ssl)
+    try:
+        grafana_version = get_grafana_version(grafana_url, verify_ssl)
+    except KeyError as error:
+        if not grafana_version:
+            raise Exception("Grafana version is not set via the config-file or provided as environment variable. Nor is it available via the api.") from error
+
     minimum_version = version.parse('9.4.0')
 
     if minimum_version <= grafana_version:

--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -21,7 +21,7 @@ def main(args, settings, file_path):
         grafana_version = get_grafana_version(grafana_url, verify_ssl)
     except KeyError as error:
         if not grafana_version:
-            raise Exception("Grafana version is not set via the config-file or provided as environment variable. Nor is it available via the api.") from error
+            raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -437,7 +437,10 @@ def add_user_to_org(org_id, payload, grafana_url, http_post_headers, verify_ssl,
 def get_grafana_version(grafana_url, verify_ssl):
     r = requests.get('{0}/api/health'.format(grafana_url), verify=verify_ssl)
     if r.status_code == 200:
-        return version.parse(r.json()['version'])
+        if 'version' in r.json().keys():
+            return version.parse(r.json()['version'])
+        else:
+            raise KeyError("Unable to get version, returned respone: {0}".format(r.json))
     else:
         raise Exception("Unable to get version, returned response: {0}".format(r.status_code))
 

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -18,6 +18,7 @@ def main(config_path):
     grafana_token = config.get('grafana', {}).get('token', '')
     grafana_search_api_limit = config.get('grafana', {}).get('search_api_limit', 5000)
     grafana_default_user_password = config.get('grafana', {}).get('default_user_password', '00000000')
+    grafana_version = config.get('grafana', {}).get('version', None)
 
     debug = config.get('general', {}).get('debug', True)
     api_health_check = config.get('general', {}).get('api_health_check', True)
@@ -56,6 +57,7 @@ def main(config_path):
     TOKEN = os.getenv('GRAFANA_TOKEN', grafana_token)
     SEARCH_API_LIMIT = os.getenv('SEARCH_API_LIMIT', grafana_search_api_limit)
     DEFAULT_USER_PASSWORD = os.getenv('DEFAULT_USER_PASSWORD', grafana_default_user_password)
+    GRAFANA_VERSION = os.getenv('GRAFANA_VERSION', grafana_version)
 
     AWS_S3_BUCKET_NAME = os.getenv('AWS_S3_BUCKET_NAME', aws_s3_bucket_name)
     AWS_S3_BUCKET_KEY = os.getenv('AWS_S3_BUCKET_KEY', aws_s3_bucket_key)
@@ -119,6 +121,7 @@ def main(config_path):
     TIMESTAMP = datetime.today().strftime(backup_file_format)
 
     config_dict['GRAFANA_URL'] = GRAFANA_URL
+    config_dict['GRAFANA_VERSION'] = GRAFANA_VERSION
     config_dict['GRAFANA_ADMIN_ACCOUNT'] = ADMIN_ACCOUNT
     config_dict['GRAFANA_ADMIN_PASSWORD'] = ADMIN_PASSWORD
 

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -15,8 +15,16 @@ def main(args, settings):
     pretty_print = settings.get('PRETTY_PRINT')
     folder_path = '{0}/alert_rules/{1}'.format(backup_dir, timestamp)
     log_file = 'alert_rules_{0}.txt'.format(timestamp)
+    grafana_version_string = settings.get('GRAFANA_VERSION')
+    if grafana_version_string:
+      grafana_version = version.parse(grafana_version_string)
 
-    grafana_version = get_grafana_version(grafana_url, verify_ssl)
+    try:
+        grafana_version = get_grafana_version(grafana_url, verify_ssl)
+    except KeyError as error:
+        if not grafana_version:
+            raise Exception("Grafana version is not set via the config-file or provided as environment variable. Nor is it available via the api.") from error
+
     minimum_version = version.parse('9.4.0')
 
     if minimum_version <= grafana_version:

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -23,7 +23,7 @@ def main(args, settings):
         grafana_version = get_grafana_version(grafana_url, verify_ssl)
     except KeyError as error:
         if not grafana_version:
-            raise Exception("Grafana version is not set via the config-file or provided as environment variable. Nor is it available via the api.") from error
+            raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 


### PR DESCRIPTION
within the grafana-config the version can be hidden
- as a fall back the version can be provided
  - in the config-file
  - as environment variable

Fixes: https://github.com/ysde/grafana-backup-tool/issues/225

Note: I messed up our branch and by fixing it, github decided to close the original pull request: https://github.com/ysde/grafana-backup-tool/pull/226

Sorry for that.