### PR TITLE
added http headers to get_grafana_version request

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -18,7 +18,7 @@ def main(args, settings, file_path):
         data = f.read()
 
     try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl)
+        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
     except KeyError as error:
         if not grafana_version:
             raise Exception("Grafana version is not set.") from error

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -434,8 +434,8 @@ def add_user_to_org(org_id, payload, grafana_url, http_post_headers, verify_ssl,
     return send_grafana_post('{0}/api/orgs/{1}/users'.format(grafana_url, org_id), payload, http_post_headers, verify_ssl, client_cert,
                              debug)
 
-def get_grafana_version(grafana_url, verify_ssl):
-    r = requests.get('{0}/api/health'.format(grafana_url), verify=verify_ssl)
+def get_grafana_version(grafana_url, verify_ssl, http_get_headers):
+    r = requests.get('{0}/api/health'.format(grafana_url), verify=verify_ssl, headers=http_get_headers)
     if r.status_code == 200:
         if 'version' in r.json().keys():
             version_str = r.json()['version']

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -20,7 +20,7 @@ def main(args, settings):
       grafana_version = version.parse(grafana_version_string)
 
     try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl)
+        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
     except KeyError as error:
         if not grafana_version:
             raise Exception("Grafana version is not set.") from error


### PR DESCRIPTION
Without the headers it will fail while running behind a reverse proxy and running towards https://localhost from same machine. This fixes the issue and the backup completes without problem.