### PR TITLE
feat: consolidate s3 logic, use default providers chain

### DIFF
--- a/grafana_backup/s3_common.py
+++ b/grafana_backup/s3_common.py
@@ -6,12 +6,18 @@ def get_boto_session(settings) -> boto3.Session:
     aws_access_key_id = settings.get("AWS_ACCESS_KEY_ID")
     aws_secret_access_key = settings.get("AWS_SECRET_ACCESS_KEY")
 
-    session = boto3.Session(
+    # If no credentials are provided, boto3 will use the default credentials provider chain.
+    if aws_access_key_id is None or aws_secret_access_key is None:
+        return boto3.Session(
+            region_name=aws_default_region,
+        )
+
+    # Otherwise, use the provided credentials.
+    return boto3.Session(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         region_name=aws_default_region,
     )
-    return session
 
 def get_s3_resource(settings):
     session = get_boto_session(settings)

--- a/grafana_backup/s3_common.py
+++ b/grafana_backup/s3_common.py
@@ -1,0 +1,33 @@
+import boto3
+from botocore.exceptions import NoCredentialsError, ClientError
+
+def get_boto_session(settings) -> boto3.Session:
+    aws_default_region = settings.get("AWS_DEFAULT_REGION")
+    aws_access_key_id = settings.get("AWS_ACCESS_KEY_ID")
+    aws_secret_access_key = settings.get("AWS_SECRET_ACCESS_KEY")
+
+    session = boto3.Session(
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        region_name=aws_default_region,
+    )
+    return session
+
+def get_s3_resource(settings):
+    session = get_boto_session(settings)
+    aws_endpoint_url = settings.get("AWS_ENDPOINT_URL")
+    s3 = session.resource(
+        service_name="s3",
+        endpoint_url=aws_endpoint_url,
+    )
+    return s3
+
+
+def get_s3_object(settings, s3_file_name):
+    aws_s3_bucket_name = settings.get('AWS_S3_BUCKET_NAME')
+    aws_s3_bucket_key = settings.get('AWS_S3_BUCKET_KEY')
+
+    s3 = get_s3_resource(settings)
+    s3_object = s3.Object(aws_s3_bucket_name, '{0}/{1}'.format(aws_s3_bucket_key, s3_file_name))
+
+    return s3_object

--- a/grafana_backup/s3_download.py
+++ b/grafana_backup/s3_download.py
@@ -2,24 +2,13 @@ import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
 from io import BytesIO 
 
+from grafana_backup.s3_common import get_s3_object
 
 def main(args, settings):
     arg_archive_file = args.get("<archive_file>", None)
-    aws_s3_bucket_name = settings.get("AWS_S3_BUCKET_NAME")
-    aws_s3_bucket_key = settings.get("AWS_S3_BUCKET_KEY")
-    aws_default_region = settings.get("AWS_DEFAULT_REGION")
-    aws_access_key_id = settings.get("AWS_ACCESS_KEY_ID")
-    aws_secret_access_key = settings.get("AWS_SECRET_ACCESS_KEY")
-    aws_endpoint_url = settings.get("AWS_ENDPOINT_URL")
 
-    session = boto3.Session(
-        aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key, region_name=aws_default_region
-    )
-
-    s3 = session.resource(service_name="s3", endpoint_url=aws_endpoint_url)
-
-    s3_path = "{0}/{1}".format(aws_s3_bucket_key, arg_archive_file)
-    s3_object = s3.Object(aws_s3_bucket_name, s3_path)
+    aws_s3_bucket_name = settings.get('AWS_S3_BUCKET_NAME')
+    s3_object = get_s3_object(settings, s3_file_name=arg_archive_file)
 
     try:
         # .read() left off on purpose, tarfile.open() takes care of that part
@@ -28,7 +17,7 @@ def main(args, settings):
         print("Download from S3 was successful")
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
-            print("Error: Key {0} does not exist in bucket {1}".format(s3_path, aws_s3_bucket_name))
+            print("Error: Key {0} does not exist in bucket {1}".format(s3_object.key, aws_s3_bucket_name))
             return False
         raise e
     except NoCredentialsError:

--- a/grafana_backup/s3_upload.py
+++ b/grafana_backup/s3_upload.py
@@ -1,33 +1,16 @@
 import boto3
 from botocore.exceptions import NoCredentialsError
 
+from grafana_backup.s3_common import get_s3_object
 
 def main(args, settings):
-    aws_s3_bucket_name = settings.get('AWS_S3_BUCKET_NAME')
-    aws_s3_bucket_key = settings.get('AWS_S3_BUCKET_KEY')
-    aws_default_region = settings.get('AWS_DEFAULT_REGION')
-    aws_access_key_id = settings.get('AWS_ACCESS_KEY_ID')
-    aws_secret_access_key = settings.get('AWS_SECRET_ACCESS_KEY')
-    aws_endpoint_url = settings.get('AWS_ENDPOINT_URL')
-
     backup_dir = settings.get('BACKUP_DIR')
     timestamp = settings.get('TIMESTAMP')
 
     s3_file_name = '{0}.tar.gz'.format(timestamp)
     archive_file = '{0}/{1}'.format(backup_dir, s3_file_name)
 
-    session = boto3.Session(
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        region_name=aws_default_region
-    )
-
-    s3 = session.resource(
-        service_name='s3',
-        endpoint_url=aws_endpoint_url
-    )
-
-    s3_object = s3.Object(aws_s3_bucket_name, '{0}/{1}'.format(aws_s3_bucket_key, s3_file_name))
+    s3_object = get_s3_object(settings, s3_file_name=s3_file_name)
 
     try:
         s3_object.put(Body=open(archive_file, 'rb'))


### PR DESCRIPTION
# What does this PR do?
1. Some of the logic in `s3_upload.py` was duplicative of the logic in `s3_download.py`. This PR consolidates this into a shared file, `s3_common.py`.
2. Boto3 has the capability to pull credentials [from context](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) (i.e. shared credentials files, assume role). This PR changes the behavior of the `s3_upload` and `s3_download` utilities to pull credentials from context if a token is not provided.
    a. The preferred method for authenticating to AWS within EKS is to use role assumption, as this avoids using long-lived credentials (like AWS tokens). This change is needed to facilitate using this approach.

## How did I test this?
I am not sure how to test this. Let me know if I need to add tests somewhere.