### PR TITLE
feat(azure-storage): allow use of AzureDefaultCredential class for uploading and downloading to azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ docker run --user $(id -u):$(id -g) --rm --name grafana-backup-tool \
 		   -e AZURE_STORAGE_CONTAINER_NAME="azure-storage-container-name" \
 		   -e AZURE_STORAGE_CONNECTION_STRING="azure-storage-connection-string"
 ```
+Or, using credentials configured through DefaultAzureCredential, see [here](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python)
+```
+           -e AZURE_STORAGE_CONTAINER_NAME="azure-storage-container-name" \
+           -e AZURE_STORAGE_ACCOUNT_URL="https://my-storage-account.blob.core.windows.net/" \
+```
 
 ***GCS Example:*** Set GCS configurations in `-e` or `grafanaSettings.json`([example](https://github.com/ysde/grafana-backup-tool/blob/master/examples/grafana-backup.example.json))
 ```

--- a/grafana_backup/azure_storage_download.py
+++ b/grafana_backup/azure_storage_download.py
@@ -1,4 +1,5 @@
 from azure.storage.blob import BlobServiceClient
+from azure.identity import DefaultAzureCredential
 import io
 
 
@@ -7,9 +8,14 @@ def main(args, settings):
 
     azure_storage_container_name = settings.get('AZURE_STORAGE_CONTAINER_NAME')
     azure_storage_connection_string = settings.get('AZURE_STORAGE_CONNECTION_STRING')
-
+    
     try:
-        blob_service_client = BlobServiceClient.from_connection_string(azure_storage_connection_string)
+        if not azure_storage_connection_string:
+            print("Azure Storage connection string is not set, using DefaultAzureCredential to authenticate")
+            blob_service_client = BlobServiceClient(account_url=settings.get('AZURE_STORAGE_ACCOUNT_URL'), credential=DefaultAzureCredential())
+        else: 
+            blob_service_client = BlobServiceClient.from_connection_string(azure_storage_connection_string)
+            
         container_client = blob_service_client.get_blob_client(container=azure_storage_container_name, blob=arg_archive_file)
         azure_storage_bytes = container_client.download_blob().readall()
         azure_storage_data = io.BytesIO(azure_storage_bytes)

--- a/grafana_backup/azure_storage_upload.py
+++ b/grafana_backup/azure_storage_upload.py
@@ -1,4 +1,5 @@
 from azure.storage.blob import BlobServiceClient
+from azure.identity import DefaultAzureCredential
 
 
 def main(args, settings):
@@ -12,7 +13,12 @@ def main(args, settings):
     archive_file = '{0}/{1}'.format(backup_dir, azure_file_name)
 
     try:
-        blob_service_client = BlobServiceClient.from_connection_string(azure_storage_connection_string)
+        if not azure_storage_connection_string:
+            print("Azure Storage connection string is not set, using DefaultAzureCredential to authenticate")
+            blob_service_client = BlobServiceClient(account_url=settings.get('AZURE_STORAGE_ACCOUNT_URL'), credential=DefaultAzureCredential())
+        else: 
+            blob_service_client = BlobServiceClient.from_connection_string(azure_storage_connection_string)
+        
         container_client = blob_service_client.get_blob_client(container=azure_storage_container_name, blob=azure_file_name)
         with open(archive_file, 'rb') as data:
             container_client.upload_blob(data)

--- a/grafana_backup/grafanaSettings.py
+++ b/grafana_backup/grafanaSettings.py
@@ -40,6 +40,7 @@ def main(config_path):
     # Cloud storage settings - Azure
     azure_storage_container_name = config.get('azure', {}).get('container_name', '')
     azure_storage_connection_string = config.get('azure', {}).get('connection_string', '')
+    azure_storage_account_url = config.get('azure', {}).get('account_url', '')
     # Cloud storage settings - GCP
     gcp_config = config.get('gcp', {})
     gcs_bucket_name = gcp_config.get('gcs_bucket_name', '')
@@ -70,6 +71,7 @@ def main(config_path):
 
     AZURE_STORAGE_CONTAINER_NAME = os.getenv('AZURE_STORAGE_CONTAINER_NAME', azure_storage_container_name)
     AZURE_STORAGE_CONNECTION_STRING = os.getenv('AZURE_STORAGE_CONNECTION_STRING', azure_storage_connection_string)
+    AZURE_STORAGE_ACCOUNT_URL = os.getenv('AZURE_STORAGE_ACCOUNT_URL', azure_storage_account_url)
 
     GCS_BUCKET_NAME = os.getenv('GCS_BUCKET_NAME', gcs_bucket_name)
     if not os.getenv('GOOGLE_APPLICATION_CREDENTIALS') and google_application_credentials:
@@ -176,6 +178,7 @@ def main(config_path):
     config_dict['AWS_ENDPOINT_URL'] = AWS_ENDPOINT_URL
     config_dict['AZURE_STORAGE_CONTAINER_NAME'] = AZURE_STORAGE_CONTAINER_NAME
     config_dict['AZURE_STORAGE_CONNECTION_STRING'] = AZURE_STORAGE_CONNECTION_STRING
+    config_dict['AZURE_STORAGE_ACCOUNT_URL'] = AZURE_STORAGE_ACCOUNT_URL
     config_dict['GCS_BUCKET_NAME'] = GCS_BUCKET_NAME
     config_dict['INFLUXDB_MEASUREMENT'] = INFLUXDB_MEASUREMENT
     config_dict['INFLUXDB_HOST'] = INFLUXDB_HOST

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ requires = [
     'azure-storage-blob',
     'google-cloud-storage',
     'influxdb',
-    'packaging'
+    'packaging',
+    'azure-identity',
 ]
 
 setup(


### PR DESCRIPTION
Using the DefaultAzureCredential class, the following methods can be used to authenticate to the storage account (also see https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python): 

```
1. A service principal configured by environment variables. See [EnvironmentCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential?view=azure-python) for more details.
2. WorkloadIdentityCredential if environment variable configuration is set by the Azure workload identity webhook.
3. An Azure managed identity. See [ManagedIdentityCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.managedidentitycredential?view=azure-python) for more details.
4. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. If multiple identities are in the cache, then the value of the environment variable AZURE_USERNAME is used to select which identity to use. See [SharedTokenCacheCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.sharedtokencachecredential?view=azure-python) for more details.
5. The identity currently logged in to the Azure CLI.
6. The identity currently logged in to Azure PowerShell.
7.The identity currently logged in to the Azure Developer CLI.
```

My use case would be to use WorkloadIdentityCredential to have my AKS cronjob authenticate to azure blob storage with it's identity, so I don't have to manage the connection_string/secret 