### PR TITLE
Fix tuple size mismatch in api_checks.py return statements

### DIFF
--- a/grafana_backup/api_checks.py
+++ b/grafana_backup/api_checks.py
@@ -15,13 +15,13 @@ def main(settings):
         (status, json_resp) = health_check(grafana_url,
                                            http_get_headers, verify_ssl, client_cert, debug)
         if not status == 200:
-            return (status, json_resp, None, None, None)
+            return (status, json_resp, None, None, None, None)
 
     if api_auth_check:
         (status, json_resp) = auth_check(grafana_url,
                                          http_get_headers, verify_ssl, client_cert, debug)
         if not status == 200:
-            return (status, json_resp, None, None, None)
+            return (status, json_resp, None, None, None, None)
 
     dashboard_uid_support, datasource_uid_support = uid_feature_check(
         grafana_url, http_get_headers, verify_ssl, client_cert, debug)


### PR DESCRIPTION
This pull request fixes a tuple size mismatch in the return statements of the api_checks.py file. The issue was causing incorrect return values when the status code was not 200. This PR ensures that the correct tuple size is returned in all cases.