### PR TITLE
Do not fetch grafana version when it is already specified via config

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -10,18 +10,19 @@ def main(args, settings, file_path):
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
+
     grafana_version_string = settings.get('GRAFANA_VERSION')
     if grafana_version_string:
-      grafana_version = version.parse(grafana_version_string)
+        grafana_version = version.parse(grafana_version_string)
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     with open(file_path, 'r') as f:
         data = f.read()
-
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/create_contact_point.py
+++ b/grafana_backup/create_contact_point.py
@@ -11,11 +11,15 @@ def main(args, settings, file_path):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    grafana_version_string = settings.get('GRAFANA_VERSION')
+    if grafana_version_string:
+        grafana_version = version.parse(grafana_version_string)
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -515,7 +515,10 @@ def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
                      verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
-    return (r.status_code, r.json())
+    try:
+        return (r.status_code, r.json())
+    except ValueError:
+        return (r.status_code, r.text)
 
 
 def send_grafana_post(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -15,16 +15,16 @@ def main(args, settings):
     pretty_print = settings.get('PRETTY_PRINT')
     folder_path = '{0}/alert_rules/{1}'.format(backup_dir, timestamp)
     log_file = 'alert_rules_{0}.txt'.format(timestamp)
+
     grafana_version_string = settings.get('GRAFANA_VERSION')
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
-
-    try:
-        grafana_version = get_grafana_version(
-            grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/save_contact_points.py
+++ b/grafana_backup/save_contact_points.py
@@ -15,16 +15,16 @@ def main(args, settings):
     pretty_print = settings.get('PRETTY_PRINT')
     folder_path = '{0}/contact_points/{1}'.format(backup_dir, timestamp)
     log_file = 'contact_points_{0}.txt'.format(timestamp)
-    grafana_version_string = settings.get('GRAFANA_VERSION')
 
+    grafana_version_string = settings.get('GRAFANA_VERSION')
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
-
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.0.0')
     if minimum_version <= grafana_version:

--- a/grafana_backup/save_notification_policies.py
+++ b/grafana_backup/save_notification_policies.py
@@ -15,16 +15,16 @@ def main(args, settings):
     pretty_print = settings.get('PRETTY_PRINT')
     folder_path = '{0}/notification_policies/{1}'.format(backup_dir, timestamp)
     log_file = 'notification_policies_{0}.txt'.format(timestamp)
-    grafana_version_string = settings.get('GRAFANA_VERSION')
 
+    grafana_version_string = settings.get('GRAFANA_VERSION')
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
-
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.0.0')
     if minimum_version <= grafana_version:

--- a/grafana_backup/update_notification_policy.py
+++ b/grafana_backup/update_notification_policy.py
@@ -11,11 +11,15 @@ def main(args, settings, file_path):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    grafana_version_string = settings.get('GRAFANA_VERSION')
+    if grafana_version_string:
+        grafana_version = version.parse(grafana_version_string)
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 


### PR DESCRIPTION
As mentioned before in #184 Amazon Managed Grafana does not support the `api/health` endpoint. The mentioned PR did a fix to not do the health check but the same call was still being used to fetch the grafana version. This was making the backup to fail for any Amazon Grafana users.

In the codebase the `GRAFANA_VERSION` was already being parsed in different places but then the API call took precedence even when it was defined. So in this PR I basically made a conditional to not fetch the version with API calls if it is defined.