### PR TITLE
Added support for notification policy restore 

### DIFF
--- a/grafana_backup/restore.py
+++ b/grafana_backup/restore.py
@@ -97,8 +97,7 @@ def main(args, settings):
     restore_functions['folder_permission'] = update_folder_permissions
     restore_functions['alert_rule'] = create_alert_rule
     restore_functions['contact_point'] = create_contact_point
-    # There are some issues of notification policy restore api, it will lock the notification policy page and cannot be edited.
-    # restore_functions['notification_policys'] = update_notification_policy
+    restore_functions['notification_policys'] = update_notification_policy
 
     if sys.version_info >= (3,):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/grafana_backup/update_notification_policy.py
+++ b/grafana_backup/update_notification_policy.py
@@ -6,6 +6,7 @@ from packaging import version
 def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_post_headers["X-Disable-Provenance"] = "true"
     http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')


### PR DESCRIPTION
Currently Notification policy restore is disabled. 

As commented this was due to Notification policy becoming uneditable after restore. 

This is caused due to the default behaviour in Grafana versions greater than 9 where objects created from API calls are uneditable. 

As suggested in Grafana documentation, adding the **X-Disable-Provenance** and setting the value to true solves this issue. 