### PR TITLE
Fix empty body issue when GET fails

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -31,7 +31,7 @@ def main(args, settings, file_path):
         uid = alert_rule['uid']
         get_response= get_alert_rule(uid, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         status_code=get_response[0]
-        print("Got a code: {0}", status_code)
+        print("Got a code: {0}".format(status_code))
         if status_code == 404:
            http_post_headers['x-disable-provenance']='*'
            result = create_alert_rule(json.dumps(alert_rule), grafana_url, http_post_headers, verify_ssl, client_cert, debug)

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -515,7 +515,10 @@ def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
                      verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
-    return (r.status_code, r.json())
+    if not r.ok:
+        return (r.status_code, '{}')
+    else:
+        return (r.status_code, r.json())
 
 
 def send_grafana_post(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):


### PR DESCRIPTION
If GET fails, the body is empty, so an attempt to convert the body to JSON raises an exception.

The solution here is to return a valid empty JSON body to the caller, that might expect a valid JSON.

This problem has been tackled in other places (but not in `set_user_role` nor `set_grafana_put`) in different ways.
* `get_grafana_version` does not attempt anything if status is not 200
* `log_response` catches `ValueError` exceptions and then logs `r.text` (fine, because print can handle `None`)
* `set_grafana_post` catches `ValueError` and then returns `r.text`.

I did not go for the same approach as `set_grafana_post` because I believe the caller should always receive a valid JSON. 