### PR TITLE
Conditional version check for resources

### DIFF
--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -13,17 +13,18 @@ def main(args, settings, file_path):
     grafana_version_string = settings.get('GRAFANA_VERSION')
     if grafana_version_string:
       grafana_version = version.parse(grafana_version_string)
+    else:
+
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
+
+    minimum_version = version.parse('9.4.0')
 
     with open(file_path, 'r') as f:
         data = f.read()
-
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
-
-    minimum_version = version.parse('9.4.0')
 
     if minimum_version <= grafana_version:
         alert_rule = json.loads(data)

--- a/grafana_backup/create_contact_point.py
+++ b/grafana_backup/create_contact_point.py
@@ -11,11 +11,17 @@ def main(args, settings, file_path):
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
 
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    grafana_version_string = settings.get('GRAFANA_VERSION')
+
+    if grafana_version_string:
+        grafana_version = version.parse(grafana_version_string)
+    else:
+
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -473,9 +473,6 @@ def search_contact_points(grafana_url, http_get_headers, verify_ssl, client_cert
 def create_contact_point(json_palyload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
     return send_grafana_post('{0}/api/v1/provisioning/contact-points'.format(grafana_url), json_palyload, http_post_headers, verify_ssl, client_cert, debug)
 
-def update_contact_point(uid, json_palyload, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
-    return send_grafana_put('{0}/api/v1/provisioning/contact-points/{1}'.format(grafana_url, uid), json_palyload, http_post_headers, verify_ssl, client_cert, debug)
-
 
 def search_notification_policies(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     return send_grafana_get('{0}/api/v1/provisioning/policies'.format(grafana_url), http_get_headers, verify_ssl, client_cert, debug)
@@ -488,6 +485,7 @@ def update_notification_policy(json_palyload, grafana_url, http_post_headers, ve
 def get_grafana_version(grafana_url, verify_ssl, http_get_headers):
     r = requests.get('{0}/api/health'.format(grafana_url),
                      verify=verify_ssl, headers=http_get_headers)
+
     if r.status_code == 200:
         if 'version' in r.json().keys():
             version_str = r.json()['version']
@@ -515,7 +513,13 @@ def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
                      verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
-    return (r.status_code, r.json())
+
+    if r.text:
+        json_response = r.json()
+    else:
+        json_response = None 
+
+    return (r.status_code, json_response)
 
 
 def send_grafana_post(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):

--- a/grafana_backup/save_alert_rules.py
+++ b/grafana_backup/save_alert_rules.py
@@ -19,12 +19,13 @@ def main(args, settings):
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
 
-    try:
-        grafana_version = get_grafana_version(
-            grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    else:
+        try:
+            grafana_version = get_grafana_version(
+                grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.4.0')
 

--- a/grafana_backup/save_contact_points.py
+++ b/grafana_backup/save_contact_points.py
@@ -19,12 +19,12 @@ def main(args, settings):
 
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
-
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+    else:
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.0.0')
     if minimum_version <= grafana_version:

--- a/grafana_backup/save_notification_policies.py
+++ b/grafana_backup/save_notification_policies.py
@@ -19,12 +19,13 @@ def main(args, settings):
 
     if grafana_version_string:
         grafana_version = version.parse(grafana_version_string)
+    else:
 
-    try:
-        grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
-    except KeyError as error:
-        if not grafana_version:
-            raise Exception("Grafana version is not set.") from error
+        try:
+            grafana_version = get_grafana_version(grafana_url, verify_ssl, http_get_headers)
+        except KeyError as error:
+            if not grafana_version:
+                raise Exception("Grafana version is not set.") from error
 
     minimum_version = version.parse('9.0.0')
     if minimum_version <= grafana_version:


### PR DESCRIPTION
Currently there is an envvar for the GRAFANA_VERSION. But even if you set it, the lib still calls out to the health check API. In the case of AWS-managed Grafana that API is disabled. It's best that if the GRAFANA_VERSION is set we simply skip the API request.