### PR TITLE
Deal with non json body

### DIFF
--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -515,7 +515,10 @@ def send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug):
                      verify=verify_ssl, cert=client_cert)
     if debug:
         log_response(r)
-    return (r.status_code, r.json())
+    try:
+       return (r.status_code, r.json())
+    except ValueError:
+       return (r.status_code, r.text)
 
 
 def send_grafana_post(url, json_payload, http_post_headers, verify_ssl=False, client_cert=None, debug=True):


### PR DESCRIPTION
Grafana now returns no body on a 404 call for the alert rules. It fails to parse the body and throws an exception. This fix is to catch the exception and return what it can to the calling code.