### PR TITLE
Updated auth check function to use serviceaccount api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.5.1] - 2025-07-08
+
+### Changed
+- Grafana removes "api/auth/keys" endpoint used for auth check, replace with "api/serviceaccounts/search"
+
 # [1.5.0] - 2023-11-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [1.5.1] - 2025-07-08
 
 ### Changed
-- Grafana removes "api/auth/keys" endpoint used for auth check, replace with "api/serviceaccounts/search"
+- In Grafana latest release API keys deprecated and removed "api/auth/keys" endpoint used for auth check, replace with "api/serviceaccounts/search"
 
 # [1.5.0] - 2023-11-10
 

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -13,7 +13,7 @@ def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
 
 
 def auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
-    url = '{0}/api/auth/keys'.format(grafana_url)
+    url = '{0}/api/serviceaccounts/search'.format(grafana_url)
     print("\n[Pre-Check] grafana auth check: {0}".format(url))
     return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 


### PR DESCRIPTION
In Grafana's recent release, they deprecated API Key and remove the respective api's causing the auth_check function to fail with 404 Not found. Replace the "api/auth/keys" with "api/serviceaccounts/serach". Technically any authentciated api can be used here to check the auth.