### PR TITLE
[fix][issue #293] versions array has another level of nesting to be broken into

### DIFF
--- a/grafana_backup/save_dashboard_versions.py
+++ b/grafana_backup/save_dashboard_versions.py
@@ -55,6 +55,10 @@ def get_versions_and_save(dashboards, folder_path, log_file, grafana_url, http_g
 def get_individual_versions(versions, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug, pretty_print):
     file_path = folder_path + '/' + log_file
     if versions:
+        versions = versions['versions']
+    else:
+        raise RuntimeError("versions, while getting individual versions broke(not present)")
+    if versions:
         with open(u"{0}".format(file_path), 'w') as f:
             for version in versions:
                 (status, content) = get_version(version['dashboardId'], version['version'], grafana_url, http_get_headers, verify_ssl, client_cert, debug)


### PR DESCRIPTION
fixes #293 
@antifuchs @gustavosoares @aerickson @suhlig @danrue Can you verify?

Previously, without this fix, I tried printing versions using the following code piece: 
```python

def get_individual_versions(versions, folder_path, log_file, grafana_url, http_get_headers, verify_ssl, client_cert, debug, pretty_print):
    file_path = folder_path + '/' + log_file
    



    # I added this part
    #########################
    with open("versions.txt", "w") as f:


        f.write(f"{folder_path} -> {repr(versions)}\n")
    #############################
    
    if versions:
        with open(u"{0}".format(file_path), 'w') as f:
            for version in versions:
                print(f"{{  versions: {type(version)}: {version} }}")
                (status, content) = get_version(version['dashboardId'], version['version'], grafana_url, http_get_headers, verify_ssl, client_cert, debug)
                if status == 200:
                    save_version(str(version['version']), content, folder_path, pretty_print)
                    f.write('{0}\n'.format(version['version']))

```


and we needed access to versions['versions'].